### PR TITLE
ci: drop always-failing Vercel notify job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,14 +56,3 @@ jobs:
       - run: npm run build
         env:
           NEXT_TELEMETRY_DISABLED: "1"
-
-  # Report combined status back to Vercel once the gates pass.
-  notify-vercel:
-    name: Notify Vercel
-    needs: [lint, format, build]
-    runs-on: ubuntu-latest
-    if: github.event_name == 'push'
-    steps:
-      - uses: vercel/repository-dispatch/actions/status@v1
-        with:
-          name: "Vercel - rin-contact: CI"


### PR DESCRIPTION
Follow-up to #11. The push-to-`v5` run went red because of the **Notify Vercel** job — `vercel/repository-dispatch/actions/status@v1` only works under a `repository_dispatch` event from Vercel (it reads that dispatch payload). This workflow triggers on `push`/`pull_request`, so the step fails every time. It was inherited from the old `lint.yml`, where it was also broken.

Vercel deploys via its native Git integration regardless, so the job was dead weight dragging the run red despite **Lint ✓** and **Build ✓**.

Pipeline is now: **lint + format (non-blocking) + build**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)