### PR TITLE
chore: one-time Prettier pass + make format gate blocking

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,10 +30,6 @@ jobs:
   format:
     name: Format check
     runs-on: ubuntu-latest
-    # Transitional: the codebase predates Prettier, so drift is reported as an
-    # annotation rather than blocking CI. Remove once a one-time `npm run format`
-    # pass has landed (track the format commit in .git-blame-ignore-revs).
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,16 @@
+# Dependencies
+node_modules/
+
+# Build output
+.next/
+out/
+build/
+coverage/
+
+# Generated / vendored — not hand-edited
+package-lock.json
+public/sw.js
+
+# Agent tooling (kept out of formatting)
+.claude/
+.agents/

--- a/components/knowledge/content/anomaly-detection.jsx
+++ b/components/knowledge/content/anomaly-detection.jsx
@@ -9,8 +9,18 @@ import { KSection, Callout, Figure, Term } from "@/components/knowledge/Knowledg
  */
 
 const CLOUD = [
-  [70, 70], [90, 60], [105, 82], [85, 95], [120, 70], [100, 50],
-  [130, 88], [115, 100], [78, 80], [110, 64], [95, 74], [125, 56],
+  [70, 70],
+  [90, 60],
+  [105, 82],
+  [85, 95],
+  [120, 70],
+  [100, 50],
+  [130, 88],
+  [115, 100],
+  [78, 80],
+  [110, 64],
+  [95, 74],
+  [125, 56],
 ];
 
 function IsolationFigure({ caption, ariaLabel, normalLabel, anomalyLabel, cutsLabel }) {
@@ -25,12 +35,51 @@ function IsolationFigure({ caption, ariaLabel, normalLabel, anomalyLabel, cutsLa
         {CLOUD.map(([x, y], i) => (
           <circle key={i} cx={x} cy={y} r="3" fill="currentColor" opacity="0.5" />
         ))}
-        <text x="100" y="128" textAnchor="middle" fontSize="9" fontFamily="monospace" fill="currentColor" opacity="0.7">{normalLabel}</text>
+        <text
+          x="100"
+          y="128"
+          textAnchor="middle"
+          fontSize="9"
+          fontFamily="monospace"
+          fill="currentColor"
+          opacity="0.7"
+        >
+          {normalLabel}
+        </text>
         <circle cx="350" cy="56" r="5" fill="#FF3C3C" />
-        <text x="350" y="80" textAnchor="middle" fontSize="9" fontFamily="monospace" fill="#FF3C3C">{anomalyLabel}</text>
-        <line x1="300" y1="30" x2="300" y2="110" stroke="#FF3C3C" strokeWidth="1" strokeDasharray="4 3" opacity="0.7" />
-        <line x1="300" y1="44" x2="400" y2="44" stroke="#FF3C3C" strokeWidth="1" strokeDasharray="4 3" opacity="0.7" />
-        <text x="350" y="128" textAnchor="middle" fontSize="9" fontFamily="monospace" fill="#FF3C3C">{cutsLabel}</text>
+        <text x="350" y="80" textAnchor="middle" fontSize="9" fontFamily="monospace" fill="#FF3C3C">
+          {anomalyLabel}
+        </text>
+        <line
+          x1="300"
+          y1="30"
+          x2="300"
+          y2="110"
+          stroke="#FF3C3C"
+          strokeWidth="1"
+          strokeDasharray="4 3"
+          opacity="0.7"
+        />
+        <line
+          x1="300"
+          y1="44"
+          x2="400"
+          y2="44"
+          stroke="#FF3C3C"
+          strokeWidth="1"
+          strokeDasharray="4 3"
+          opacity="0.7"
+        />
+        <text
+          x="350"
+          y="128"
+          textAnchor="middle"
+          fontSize="9"
+          fontFamily="monospace"
+          fill="#FF3C3C"
+        >
+          {cutsLabel}
+        </text>
       </svg>
     </Figure>
   );
@@ -43,14 +92,14 @@ function EnBody() {
       <p>
         Most analysis is about the typical case — the average, the trend, the pattern.{" "}
         <Term>Anomaly detection</Term> is about the opposite: finding the rare points that{" "}
-        <em>don't</em> fit, because in a great many domains the unusual case is the one that matters.
-        A fraudulent transaction, a security breach, a sensor about to fail, a record that warrants a
-        closer look — they're all needles in a haystack, and the haystack is enormous.
+        <em>don't</em> fit, because in a great many domains the unusual case is the one that
+        matters. A fraudulent transaction, a security breach, a sensor about to fail, a record that
+        warrants a closer look — they're all needles in a haystack, and the haystack is enormous.
       </p>
       <p>
         It's a discipline I lean on directly in intelligence and integrity work, where the whole job
-        is often to surface the few cases worth investigating from a sea of normal ones. This page is
-        the practical landscape: what an anomaly is, the methods, and the trade-off that quietly
+        is often to surface the few cases worth investigating from a sea of normal ones. This page
+        is the practical landscape: what an anomaly is, the methods, and the trade-off that quietly
         decides whether a detector is actually useful.
       </p>
 
@@ -58,15 +107,15 @@ function EnBody() {
         <p>
           An <Term>anomaly</Term> (or outlier) is a data point that deviates so much from the rest
           that it likely came from a different process. The premise is that{" "}
-          <strong>"different" often means "interesting"</strong> — the deviation is a signal of fraud,
-          error, failure, or threat, not just noise. The goal isn't to model the anomalies (you
-          usually can't — they're rare and varied); it's to model what <em>normal</em> looks like well
-          enough that the abnormal stands out.
+          <strong>"different" often means "interesting"</strong> — the deviation is a signal of
+          fraud, error, failure, or threat, not just noise. The goal isn't to model the anomalies
+          (you usually can't — they're rare and varied); it's to model what <em>normal</em> looks
+          like well enough that the abnormal stands out.
         </p>
         <p>
-          That framing is the key to the whole field. You learn the shape of "normal" from the bulk of
-          the data, then flag whatever falls far outside it. Everything below is a different way of
-          defining "far outside".
+          That framing is the key to the whole field. You learn the shape of "normal" from the bulk
+          of the data, then flag whatever falls far outside it. Everything below is a different way
+          of defining "far outside".
         </p>
       </KSection>
 
@@ -84,15 +133,15 @@ function EnBody() {
           </li>
           <li>
             <Term>Collective anomalies</Term> — a <em>group</em> of points that's abnormal together
-            even though each is individually fine (a sudden burst of small transactions, a coordinated
-            pattern of logins).
+            even though each is individually fine (a sudden burst of small transactions, a
+            coordinated pattern of logins).
           </li>
         </ul>
         <p>
           Knowing which you're hunting for matters: a method that catches point anomalies will sail
           straight past a contextual one. Context and sequence (the{" "}
-          <Link href="/knowledge/time-series-analysis">time-series</Link> view) often have to be built
-          in deliberately.
+          <Link href="/knowledge/time-series-analysis">time-series</Link> view) often have to be
+          built in deliberately.
         </p>
       </KSection>
 
@@ -105,8 +154,9 @@ function EnBody() {
             <Link href="/knowledge/probability">base-rate</Link> trap from the probability page.
           </li>
           <li>
-            <Term>They're usually unlabelled</Term> — you rarely have a clean set of known anomalies to
-            learn from, so most of the work is <em>unsupervised</em>: define normal, flag deviations.
+            <Term>They're usually unlabelled</Term> — you rarely have a clean set of known anomalies
+            to learn from, so most of the work is <em>unsupervised</em>: define normal, flag
+            deviations.
           </li>
           <li>
             <Term>They evolve</Term> — fraudsters change tactics, systems drift, so today's normal
@@ -119,18 +169,18 @@ function EnBody() {
         <p>
           The simplest detectors are statistical: assume a distribution for "normal" and flag what's
           improbable under it. For roughly bell-shaped data, the <Term>z-score</Term> flags points
-          more than a few standard deviations from the mean; for skewed data, the <Term>IQR</Term> rule
-          (points beyond 1.5× the interquartile range) is more robust. These are fast, transparent, and
-          a fine first pass.
+          more than a few standard deviations from the mean; for skewed data, the <Term>IQR</Term>{" "}
+          rule (points beyond 1.5× the interquartile range) is more robust. These are fast,
+          transparent, and a fine first pass.
         </p>
         <Callout type="pitfall">
           <p>
-            The catch is they assume a shape and look one feature at a time. A point can be perfectly
-            normal on every individual axis yet bizarre in <em>combination</em> — a young age and a
-            senior job title are each fine, together unusual. Real anomaly detection is multivariate,
-            which is why the distance- and model-based methods below exist. (And the usual caveat:{" "}
-            <strong>standardise</strong> features first, or distance is dominated by the biggest-scaled
-            one.)
+            The catch is they assume a shape and look one feature at a time. A point can be
+            perfectly normal on every individual axis yet bizarre in <em>combination</em> — a young
+            age and a senior job title are each fine, together unusual. Real anomaly detection is
+            multivariate, which is why the distance- and model-based methods below exist. (And the
+            usual caveat: <strong>standardise</strong> features first, or distance is dominated by
+            the biggest-scaled one.)
           </p>
         </Callout>
       </KSection>
@@ -156,27 +206,29 @@ function EnBody() {
         </ul>
         <p>
           The trade-off: distance-based methods struggle in very high dimensions (the{" "}
-          <Link href="/knowledge/pca-dimensionality-reduction">curse of dimensionality</Link> again —
-          everything is far from everything), so reducing dimensions first often helps.
+          <Link href="/knowledge/pca-dimensionality-reduction">curse of dimensionality</Link> again
+          — everything is far from everything), so reducing dimensions first often helps.
         </p>
       </KSection>
 
       <KSection id="model" eyebrow="06" title="Model-based detection">
-        <p>The most popular modern approaches learn a model of normal and score deviation from it:</p>
+        <p>
+          The most popular modern approaches learn a model of normal and score deviation from it:
+        </p>
         <ul>
           <li>
             <Term>Isolation Forest</Term> — the clever, widely-used default. Instead of modelling
-            density, it randomly splits the data and notes that <em>anomalies are easy to isolate</em>:
-            a weird point gets cut off from the rest in just a few random splits, while normal points
-            take many. The shorter the path to isolate a point, the more anomalous it is. Fast, scales
-            well, and needs little tuning.
+            density, it randomly splits the data and notes that{" "}
+            <em>anomalies are easy to isolate</em>: a weird point gets cut off from the rest in just
+            a few random splits, while normal points take many. The shorter the path to isolate a
+            point, the more anomalous it is. Fast, scales well, and needs little tuning.
           </li>
           <li>
             <Term>Autoencoders</Term> — a{" "}
             <Link href="/knowledge/statistical-machine-learning">neural network</Link> trained to
-            compress and reconstruct normal data. Show it an anomaly and it reconstructs it badly (it
-            never learned that shape), so a high <em>reconstruction error</em> flags the outlier.
-            Powerful for complex, high-dimensional data like images or sequences.
+            compress and reconstruct normal data. Show it an anomaly and it reconstructs it badly
+            (it never learned that shape), so a high <em>reconstruction error</em> flags the
+            outlier. Powerful for complex, high-dimensional data like images or sequences.
           </li>
         </ul>
 
@@ -192,9 +244,9 @@ function EnBody() {
       <KSection id="tradeoff" eyebrow="07" title="The alert-fatigue trade-off">
         <p>
           Here's the trade-off that decides whether a detector is actually useful, and it's the{" "}
-          <Link href="/knowledge/statistics">precision/recall</Link> tension from the statistics page
-          in its most consequential form. Most detectors have a sensitivity dial (the "contamination"
-          or threshold):
+          <Link href="/knowledge/statistics">precision/recall</Link> tension from the statistics
+          page in its most consequential form. Most detectors have a sensitivity dial (the
+          "contamination" or threshold):
         </p>
         <ul>
           <li>
@@ -208,25 +260,26 @@ function EnBody() {
         <Callout type="pitfall">
           <p>
             <strong>Alert fatigue is the silent killer of anomaly systems.</strong> A detector that
-            cries wolf — flooding analysts with false positives — gets ignored, and then it misses the
-            real anomaly because nobody's listening any more. A system with great recall and terrible
-            precision is <em>worse</em> than no system, because it burns the trust and the time of the
-            people meant to act on it. The fix is rarely a fancier model — it's tuning the threshold to
-            what humans can actually triage, and <strong>combining model scores with domain rules</strong>{" "}
-            so the alerts that surface are the ones worth a person's attention.
+            cries wolf — flooding analysts with false positives — gets ignored, and then it misses
+            the real anomaly because nobody's listening any more. A system with great recall and
+            terrible precision is <em>worse</em> than no system, because it burns the trust and the
+            time of the people meant to act on it. The fix is rarely a fancier model — it's tuning
+            the threshold to what humans can actually triage, and{" "}
+            <strong>combining model scores with domain rules</strong> so the alerts that surface are
+            the ones worth a person's attention.
           </p>
         </Callout>
       </KSection>
 
       <KSection id="evaluate" eyebrow="08" title="Judging without labels">
         <p>
-          Evaluation is hard precisely because you usually lack labels — if you knew the anomalies, you
-          wouldn't need to detect them. In practice you validate on whatever labelled subset you have
-          (past confirmed cases), use the{" "}
-          <Link href="/knowledge/statistics">precision/recall/F1</Link> family rather than accuracy, and
-          lean on domain experts to confirm a sample of what's flagged. Above all, you tune to the real
-          cost: in most settings a missed anomaly and a false alarm have very different prices, and the
-          threshold should reflect that, not a default.
+          Evaluation is hard precisely because you usually lack labels — if you knew the anomalies,
+          you wouldn't need to detect them. In practice you validate on whatever labelled subset you
+          have (past confirmed cases), use the{" "}
+          <Link href="/knowledge/statistics">precision/recall/F1</Link> family rather than accuracy,
+          and lean on domain experts to confirm a sample of what's flagged. Above all, you tune to
+          the real cost: in most settings a missed anomaly and a false alarm have very different
+          prices, and the threshold should reflect that, not a default.
         </p>
       </KSection>
 
@@ -236,17 +289,17 @@ function EnBody() {
             In intelligence and integrity work, anomaly detection is often the whole task:{" "}
             <strong>surface the few cases worth investigating</strong> from a large volume of normal
             activity. The discipline on this page is exactly what keeps that useful — model "normal"
-            honestly, mind the <strong>base rate</strong> (rare events make accuracy meaningless), and
-            above all manage the <strong>alert-fatigue trade-off</strong>, because a flood of false
-            positives doesn't just waste analyst time, it gets the whole system switched off.
+            honestly, mind the <strong>base rate</strong> (rare events make accuracy meaningless),
+            and above all manage the <strong>alert-fatigue trade-off</strong>, because a flood of
+            false positives doesn't just waste analyst time, it gets the whole system switched off.
           </p>
           <p>
             It also stitches together much of this section: the{" "}
             <Link href="/knowledge/probability">base-rate</Link> reasoning, the{" "}
             <Link href="/knowledge/clustering">density</Link> view, the{" "}
             <Link href="/knowledge/statistical-machine-learning">models</Link>, and the{" "}
-            <Link href="/knowledge/statistics">precision/recall</Link> honesty — all pointed at the same
-            target: finding the signal that doesn't belong, without crying wolf.
+            <Link href="/knowledge/statistics">precision/recall</Link> honesty — all pointed at the
+            same target: finding the signal that doesn't belong, without crying wolf.
           </p>
         </Callout>
       </KSection>
@@ -259,14 +312,14 @@ function EnBody() {
               "important". Model <strong>normal</strong>, flag deviations.
             </li>
             <li>
-              Three kinds: <strong>point</strong>, <strong>contextual</strong> (odd for the context),{" "}
-              <strong>collective</strong> (odd as a group). Hard because anomalies are{" "}
+              Three kinds: <strong>point</strong>, <strong>contextual</strong> (odd for the
+              context), <strong>collective</strong> (odd as a group). Hard because anomalies are{" "}
               <strong>rare, unlabelled, and evolving</strong> (base-rate trap).
             </li>
             <li>
               Methods: <strong>statistical</strong> (z-score/IQR, but univariate),{" "}
-              <strong>distance/density</strong> (LOF, DBSCAN), <strong>model-based</strong> (isolation
-              forest — fewer cuts to isolate; autoencoders — high reconstruction error).
+              <strong>distance/density</strong> (LOF, DBSCAN), <strong>model-based</strong>{" "}
+              (isolation forest — fewer cuts to isolate; autoencoders — high reconstruction error).
             </li>
             <li>
               The key trade-off is <strong>precision vs recall</strong> via a sensitivity dial — and{" "}
@@ -284,8 +337,9 @@ function EnBody() {
           </ul>
         </Callout>
         <p className="text-[12px] text-[#9A9A9A] dark:text-[#6E6E6E] mt-6 [text-wrap:pretty]">
-          Method comparisons and the alert-fatigue framing reflect current anomaly-detection references
-          (isolation forest / LOF practice, alert-fatigue research) alongside hands-on work.
+          Method comparisons and the alert-fatigue framing reflect current anomaly-detection
+          references (isolation forest / LOF practice, alert-fatigue research) alongside hands-on
+          work.
         </p>
       </KSection>
     </>
@@ -349,8 +403,8 @@ function ZhBody() {
         <ul>
           <li>
             <Term>它们罕见</Term>——按定义如此。极端的类别不平衡意味着准确率毫无用处（一个什么都不
-            标记的检测器有 99.9% 的准确率、却 100% 没用），正是<Link href="/knowledge/probability">概率
-            页</Link>上同样的基率陷阱。
+            标记的检测器有 99.9% 的准确率、却 100% 没用），正是
+            <Link href="/knowledge/probability">概率 页</Link>上同样的基率陷阱。
           </li>
           <li>
             <Term>它们通常无标签</Term>——你很少有一套干净的、已知的异常可供学习，所以大部分工作是
@@ -397,8 +451,9 @@ function ZhBody() {
           </li>
         </ul>
         <p>
-          权衡在于：基于距离的方法在极高维中会吃力（又是<Link href="/knowledge/pca-dimensionality-reduction">维度
-          灾难</Link>——万物都远离万物），所以先降维往往有帮助。
+          权衡在于：基于距离的方法在极高维中会吃力（又是
+          <Link href="/knowledge/pca-dimensionality-reduction">维度 灾难</Link>
+          ——万物都远离万物），所以先降维往往有帮助。
         </p>
       </KSection>
 
@@ -406,8 +461,9 @@ function ZhBody() {
         <p>最流行的现代方法学得一个「正常」的模型，并为偏离它的程度打分：</p>
         <ul>
           <li>
-            <Term>孤立森林</Term>——那个聪明、被广泛使用的默认。它不去给密度建模，而是随机地切分数据，
-            并注意到<em>异常容易被孤立</em>：一个怪点只需几次随机切分就被从其余之中切出来，而正常点要
+            <Term>孤立森林</Term>
+            ——那个聪明、被广泛使用的默认。它不去给密度建模，而是随机地切分数据， 并注意到
+            <em>异常容易被孤立</em>：一个怪点只需几次随机切分就被从其余之中切出来，而正常点要
             许多次。把一个点孤立出来的路径越短，它就越异常。快、可扩展，且几乎不用调参。
           </li>
           <li>
@@ -429,8 +485,8 @@ function ZhBody() {
 
       <KSection id="tradeoff" eyebrow="07" title="告警疲劳的权衡">
         <p>
-          这是决定一个检测器是否真正有用的权衡，它是<Link href="/knowledge/statistics">统计页</Link>上
-          精确率/召回率张力最具后果的形态。大多数检测器都有一个灵敏度旋钮（「污染率」或阈值）：
+          这是决定一个检测器是否真正有用的权衡，它是<Link href="/knowledge/statistics">统计页</Link>
+          上 精确率/召回率张力最具后果的形态。大多数检测器都有一个灵敏度旋钮（「污染率」或阈值）：
         </p>
         <ul>
           <li>调高 → 抓住更多真实的异常（高召回），却被假警报淹没（低精确）。</li>
@@ -441,8 +497,8 @@ function ZhBody() {
             <strong>告警疲劳是异常系统的无声杀手。</strong>一个狼来了喊多了的检测器——用假阳性淹没
             分析师——会被无视，然后它就漏掉了真实的异常，因为没人再在听了。一个召回率极好、精确率
             极差的系统，<em>比没有系统更糟</em>，因为它烧掉了本该据以行动的人的信任与时间。修法很少
-            是一个更花哨的模型——而是把阈值调到人类实际能分诊的程度，并<strong>把模型分数与领域规则
-            结合</strong>，好让浮现出来的告警是那些值得一个人去关注的。
+            是一个更花哨的模型——而是把阈值调到人类实际能分诊的程度，并
+            <strong>把模型分数与领域规则 结合</strong>，好让浮现出来的告警是那些值得一个人去关注的。
           </p>
         </Callout>
       </KSection>
@@ -450,7 +506,8 @@ function ZhBody() {
       <KSection id="evaluate" eyebrow="08" title="无标签下的评判">
         <p>
           评估之所以难，恰恰因为你通常缺乏标签——如果你知道那些异常，你就不需要去检测它们了。实践中
-          你在你所有的任何带标签子集上验证（过去已确认的案例），用<Link href="/knowledge/statistics">精确率/召回率/F1</Link>
+          你在你所有的任何带标签子集上验证（过去已确认的案例），用
+          <Link href="/knowledge/statistics">精确率/召回率/F1</Link>
           这一族而非准确率，并倚靠领域专家来确认被标记之物的一个样本。最重要的是，你按真实的代价来
           调：在大多数场景里，一个漏掉的异常与一个假警报有着很不同的价码，而阈值应当反映这一点，而非
           一个默认值。
@@ -460,16 +517,18 @@ function ZhBody() {
       <KSection id="applied" eyebrow="09" title="它在我工作中的体现">
         <Callout type="applied" label="浮现出值得一看的那个案例">
           <p>
-            在情报与廉政工作中，异常检测往往就是整份任务：从大量正常的活动中，<strong>浮现出那少数
-            几个值得调查的案例</strong>。这一页上的纪律，正是让那件事保持有用的东西——诚实地给「正常」
-            建模、留心<strong>基率</strong>（罕见事件让准确率变得毫无意义），并且最重要的是管好
+            在情报与廉政工作中，异常检测往往就是整份任务：从大量正常的活动中，
+            <strong>浮现出那少数 几个值得调查的案例</strong>
+            。这一页上的纪律，正是让那件事保持有用的东西——诚实地给「正常」 建模、留心
+            <strong>基率</strong>（罕见事件让准确率变得毫无意义），并且最重要的是管好
             <strong>告警疲劳</strong>的权衡，因为一阵假阳性的洪流不只是浪费分析师的时间，它会让整个
             系统被关掉。
           </p>
           <p>
             它也把本板块的许多部分缝在一起：<Link href="/knowledge/probability">基率</Link>推理、
-            <Link href="/knowledge/clustering">密度</Link>视角、<Link href="/knowledge/statistical-machine-learning">模型</Link>，
-            以及<Link href="/knowledge/statistics">精确率/召回率</Link>的诚实——全都瞄准同一个目标：
+            <Link href="/knowledge/clustering">密度</Link>视角、
+            <Link href="/knowledge/statistical-machine-learning">模型</Link>， 以及
+            <Link href="/knowledge/statistics">精确率/召回率</Link>的诚实——全都瞄准同一个目标：
             找出那个不属于此处的信号，而不喊狼来了。
           </p>
         </Callout>
@@ -479,12 +538,14 @@ function ZhBody() {
         <Callout type="refresher">
           <ul className="list-disc pl-5 space-y-2">
             <li>
-              异常检测找出那些不契合的罕见点——而「不同」往往是「重要」。给<strong>正常</strong>建模，
-              标记偏离。
+              异常检测找出那些不契合的罕见点——而「不同」往往是「重要」。给<strong>正常</strong>
+              建模， 标记偏离。
             </li>
             <li>
-              三种：<strong>点</strong>、<strong>上下文</strong>（对语境而言反常）、<strong>集体</strong>
-              （作为一组反常）。难，是因为异常<strong>罕见、无标签、且不断演变</strong>（基率陷阱）。
+              三种：<strong>点</strong>、<strong>上下文</strong>（对语境而言反常）、
+              <strong>集体</strong>
+              （作为一组反常）。难，是因为异常<strong>罕见、无标签、且不断演变</strong>
+              （基率陷阱）。
             </li>
             <li>
               方法：<strong>统计</strong>（z 分数/IQR，但是单变量的）、<strong>距离/密度</strong>
@@ -492,8 +553,8 @@ function ZhBody() {
               重建误差）。
             </li>
             <li>
-              关键的权衡是经由一个灵敏度旋钮的<strong>精确率 vs 召回率</strong>——以及<strong>告警
-              疲劳</strong>：太多假阳性会让系统被无视。
+              关键的权衡是经由一个灵敏度旋钮的<strong>精确率 vs 召回率</strong>——以及
+              <strong>告警 疲劳</strong>：太多假阳性会让系统被无视。
             </li>
             <li>
               <strong>把模型分数与领域规则结合</strong>；把阈值调到人类能分诊的程度，并调到「漏报 vs

--- a/components/knowledge/content/intelligence-analysis.jsx
+++ b/components/knowledge/content/intelligence-analysis.jsx
@@ -28,16 +28,45 @@ function CycleFigure({ caption, ariaLabel, labels }) {
       >
         {CYCLE_POS.map((n, i) => {
           const next = CYCLE_POS[(i + 1) % CYCLE_POS.length];
-          return <line key={"l" + i} x1={n.x} y1={n.y} x2={next.x} y2={next.y} stroke="#FF3C3C" strokeWidth="1" opacity="0.3" />;
+          return (
+            <line
+              key={"l" + i}
+              x1={n.x}
+              y1={n.y}
+              x2={next.x}
+              y2={next.y}
+              stroke="#FF3C3C"
+              strokeWidth="1"
+              opacity="0.3"
+            />
+          );
         })}
         {CYCLE_POS.map((n, i) => {
           const accent = i === 0 || i === 3;
           return (
             <g key={i}>
-              <rect x={n.x - 48} y={n.y - 13} width="96" height="26" rx="13"
-                fill={accent ? "#FF3C3C" : "none"} fillOpacity={accent ? 0.12 : 0}
-                stroke="#FF3C3C" strokeWidth={accent ? 1.4 : 1} opacity={accent ? 1 : 0.65} />
-              <text x={n.x} y={n.y + 4} textAnchor="middle" fontSize="9" fontFamily="monospace" fill="currentColor">{labels[i]}</text>
+              <rect
+                x={n.x - 48}
+                y={n.y - 13}
+                width="96"
+                height="26"
+                rx="13"
+                fill={accent ? "#FF3C3C" : "none"}
+                fillOpacity={accent ? 0.12 : 0}
+                stroke="#FF3C3C"
+                strokeWidth={accent ? 1.4 : 1}
+                opacity={accent ? 1 : 0.65}
+              />
+              <text
+                x={n.x}
+                y={n.y + 4}
+                textAnchor="middle"
+                fontSize="9"
+                fontFamily="monospace"
+                fill="currentColor"
+              >
+                {labels[i]}
+              </text>
             </g>
           );
         })}
@@ -51,32 +80,33 @@ function EnBody() {
   return (
     <>
       <p>
-        <Term>Intelligence analysis</Term> is what data work becomes when a real decision hangs on it
-        and the picture is never complete. It's the discipline of turning fragmentary, sometimes
-        contradictory information into an <em>assessment</em> a decision-maker can act on — and being
-        honest about how confident that assessment deserves to be. The maths and models from the rest
-        of this section are tools it uses; the discipline itself is about judgement under uncertainty.
+        <Term>Intelligence analysis</Term> is what data work becomes when a real decision hangs on
+        it and the picture is never complete. It's the discipline of turning fragmentary, sometimes
+        contradictory information into an <em>assessment</em> a decision-maker can act on — and
+        being honest about how confident that assessment deserves to be. The maths and models from
+        the rest of this section are tools it uses; the discipline itself is about judgement under
+        uncertainty.
       </p>
       <p>
         It's the heart of my current work in government, and it has its own tradecraft — a body of
-        method built precisely because the hardest adversary an analyst faces isn't the subject of the
-        analysis, but the predictable ways their own mind gets things wrong. This page is that
+        method built precisely because the hardest adversary an analyst faces isn't the subject of
+        the analysis, but the predictable ways their own mind gets things wrong. This page is that
         tradecraft, made plain.
       </p>
 
       <KSection id="what" eyebrow="01" title="Data with a decision attached">
         <p>
           The defining feature of intelligence is its purpose: it exists to{" "}
-          <strong>inform a specific decision</strong>, for a specific person, who will act on it. That
-          distinguishes it from analysis done out of curiosity. An intelligence product isn't judged
-          on how clever it is, but on whether it helped someone make a better call with imperfect
-          information — under time pressure, with consequences.
+          <strong>inform a specific decision</strong>, for a specific person, who will act on it.
+          That distinguishes it from analysis done out of curiosity. An intelligence product isn't
+          judged on how clever it is, but on whether it helped someone make a better call with
+          imperfect information — under time pressure, with consequences.
         </p>
         <p>
           So intelligence is fundamentally about <em>assessment under uncertainty</em>. You will
-          almost never have all the facts; the job is to make the best-supported judgement you can from
-          what you have, state how much weight it can bear, and hand it over in time to be useful.
-          Certainty is not on offer; calibrated judgement is.
+          almost never have all the facts; the job is to make the best-supported judgement you can
+          from what you have, state how much weight it can bear, and hand it over in time to be
+          useful. Certainty is not on offer; calibrated judgement is.
         </p>
       </KSection>
 
@@ -90,21 +120,25 @@ function EnBody() {
             <Term>Direction</Term> — what does the decision-maker actually need to know? The
             requirement that drives everything.
           </li>
-          <li><Term>Collection</Term> — gather the relevant information from available sources.</li>
-          <li><Term>Processing</Term> — turn raw material into usable, organised form.</li>
+          <li>
+            <Term>Collection</Term> — gather the relevant information from available sources.
+          </li>
+          <li>
+            <Term>Processing</Term> — turn raw material into usable, organised form.
+          </li>
           <li>
             <Term>Analysis</Term> — the core: assess what it means, weigh the hypotheses, form a
             judgement.
           </li>
           <li>
-            <Term>Dissemination</Term> — deliver the assessment to the decision-maker, clearly and in
-            time.
+            <Term>Dissemination</Term> — deliver the assessment to the decision-maker, clearly and
+            in time.
           </li>
         </ul>
         <p>
-          Like the <Link href="/knowledge/applied-data-science">data-science lifecycle</Link>, it's a
-          loop, not a line — dissemination raises new questions that feed back into direction. And the
-          same lesson applies: the analysis is only as good as the question at the top, and only
+          Like the <Link href="/knowledge/applied-data-science">data-science lifecycle</Link>, it's
+          a loop, not a line — dissemination raises new questions that feed back into direction. And
+          the same lesson applies: the analysis is only as good as the question at the top, and only
           matters if it reaches the decision-maker in a form they can use.
         </p>
 
@@ -117,35 +151,38 @@ function EnBody() {
 
       <KSection id="vsdata" eyebrow="03" title="Intelligence vs data analysis">
         <p>
-          Intelligence and data analysis overlap, but the emphasis differs in a way worth naming. Data
-          analysis often asks <em>what does the data show?</em> Intelligence insists on the next step:{" "}
-          <em>what does it mean for the decision, and so what should we do?</em> The{" "}
-          <Link href="/knowledge/science-communication">"so what"</Link> isn't optional polish — it's
-          the product.
+          Intelligence and data analysis overlap, but the emphasis differs in a way worth naming.
+          Data analysis often asks <em>what does the data show?</em> Intelligence insists on the
+          next step: <em>what does it mean for the decision, and so what should we do?</em> The{" "}
+          <Link href="/knowledge/science-communication">"so what"</Link> isn't optional polish —
+          it's the product.
         </p>
         <p>
           Intelligence also routinely reasons from <em>incomplete and unreliable</em> information,
-          where a clean dataset is a luxury you don't get. So it leans less on a single number and more
-          on weighing competing explanations, grading how much each source can be trusted, and being
-          explicit about the gaps. The quantitative toolkit from the rest of this section absolutely
-          helps — but the core skill is structured reasoning under doubt.
+          where a clean dataset is a luxury you don't get. So it leans less on a single number and
+          more on weighing competing explanations, grading how much each source can be trusted, and
+          being explicit about the gaps. The quantitative toolkit from the rest of this section
+          absolutely helps — but the core skill is structured reasoning under doubt.
         </p>
       </KSection>
 
       <KSection id="bias" eyebrow="04" title="The enemy is your own mind">
         <p>
           The central insight of modern intelligence tradecraft is humbling: the biggest threat to a
-          sound assessment is not bad data — it's the analyst's own <Term>cognitive bias</Term>. Human
-          minds take shortcuts that served us on the savannah and betray us on hard problems:
+          sound assessment is not bad data — it's the analyst's own <Term>cognitive bias</Term>.
+          Human minds take shortcuts that served us on the savannah and betray us on hard problems:
         </p>
         <ul>
           <li>
-            <Term>Confirmation bias</Term> — seeing the evidence that fits the theory you already hold
-            and discounting the rest.
+            <Term>Confirmation bias</Term> — seeing the evidence that fits the theory you already
+            hold and discounting the rest.
           </li>
-          <li><Term>Anchoring</Term> — over-weighting the first piece of information you got.</li>
           <li>
-            <Term>Premature closure</Term> — settling on an answer too early and stopping the search.
+            <Term>Anchoring</Term> — over-weighting the first piece of information you got.
+          </li>
+          <li>
+            <Term>Premature closure</Term> — settling on an answer too early and stopping the
+            search.
           </li>
         </ul>
         <p>
@@ -158,74 +195,76 @@ function EnBody() {
       <KSection id="sats" eyebrow="05" title="Structured analytic techniques">
         <p>
           <Term>Structured Analytic Techniques</Term> (SATs) are formal methods that externalise
-          reasoning — get it out of your head and onto paper where its flaws show. They make analysis
-          more rigorous, more transparent, and more defensible. The most important is the workhorse of
-          the craft:
+          reasoning — get it out of your head and onto paper where its flaws show. They make
+          analysis more rigorous, more transparent, and more defensible. The most important is the
+          workhorse of the craft:
         </p>
         <Callout type="intuition">
           <p>
             <strong>Analysis of Competing Hypotheses (ACH).</strong> Instead of building a case for
             your favourite explanation, you list <em>all</em> the plausible hypotheses up front, lay
-            every piece of evidence against each in a matrix, and — crucially — look for evidence that
-            would <em>disprove</em> each one. The winner isn't the hypothesis with the most support;
-            it's the one with the least evidence <em>against</em> it. ACH directly attacks confirmation
-            bias by forcing you to try to kill your own theory, the same falsification instinct as a
-            good <Link href="/knowledge/statistics">hypothesis test</Link>.
+            every piece of evidence against each in a matrix, and — crucially — look for evidence
+            that would <em>disprove</em> each one. The winner isn't the hypothesis with the most
+            support; it's the one with the least evidence <em>against</em> it. ACH directly attacks
+            confirmation bias by forcing you to try to kill your own theory, the same falsification
+            instinct as a good <Link href="/knowledge/statistics">hypothesis test</Link>.
           </p>
         </Callout>
         <p>
-          Two more that earn their keep daily: a <Term>Key Assumptions Check</Term> — write down every
-          assumption your judgement rests on and ask what happens if each is wrong — and rigorously{" "}
-          <Term>separating the reporting from your interpretation</Term>: keeping "here's what the
-          source said" distinct from "here's what I think it means", so a reader can see exactly where
-          the facts end and your judgement begins.
+          Two more that earn their keep daily: a <Term>Key Assumptions Check</Term> — write down
+          every assumption your judgement rests on and ask what happens if each is wrong — and
+          rigorously <Term>separating the reporting from your interpretation</Term>: keeping "here's
+          what the source said" distinct from "here's what I think it means", so a reader can see
+          exactly where the facts end and your judgement begins.
         </p>
       </KSection>
 
       <KSection id="osint" eyebrow="06" title="OSINT and source grading">
         <p>
-          <Term>Open-Source Intelligence</Term> (OSINT) is intelligence drawn from publicly available
-          information — news, public records, social media, company filings, imagery. It's vast and
-          powerful, and it's exactly where the discipline matters most, because open sources are often
-          contradictory, incomplete, and sometimes deliberately deceptive.
+          <Term>Open-Source Intelligence</Term> (OSINT) is intelligence drawn from publicly
+          available information — news, public records, social media, company filings, imagery. It's
+          vast and powerful, and it's exactly where the discipline matters most, because open
+          sources are often contradictory, incomplete, and sometimes deliberately deceptive.
         </p>
         <p>
           So you never take a source at face value — you <Term>grade</Term> it on two separate axes:
-          how <em>reliable</em> is the source (its track record and access), and how <em>credible</em>{" "}
-          is this particular piece of information (does it fit what else is known, is it corroborated)?
-          A reliable source can still pass on a dubious claim, and an unreliable one can occasionally
-          be right — keeping the two judgements apart is the discipline. Corroborate across independent
-          sources, trace claims to their origin, and stay alert to the <Term>verification</Term>{" "}
-          problem that the same false story echoing across ten sites is still one claim, not ten.
+          how <em>reliable</em> is the source (its track record and access), and how{" "}
+          <em>credible</em> is this particular piece of information (does it fit what else is known,
+          is it corroborated)? A reliable source can still pass on a dubious claim, and an
+          unreliable one can occasionally be right — keeping the two judgements apart is the
+          discipline. Corroborate across independent sources, trace claims to their origin, and stay
+          alert to the <Term>verification</Term> problem that the same false story echoing across
+          ten sites is still one claim, not ten.
         </p>
       </KSection>
 
       <KSection id="language" eyebrow="07" title="The language of confidence">
         <p>
           Because intelligence trades in uncertainty, <em>how</em> you express confidence is part of
-          the product. Vague words betray the reader: "likely" might mean 55% to one person and 90% to
-          another. Good practice uses a consistent set of <Term>probability yardsticks</Term> — a
-          defined ladder from "remote" through "even chance" to "almost certain" — and separates that
-          estimative likelihood from your <em>confidence</em> in the underlying evidence (a
+          the product. Vague words betray the reader: "likely" might mean 55% to one person and 90%
+          to another. Good practice uses a consistent set of <Term>probability yardsticks</Term> — a
+          defined ladder from "remote" through "even chance" to "almost certain" — and separates
+          that estimative likelihood from your <em>confidence</em> in the underlying evidence (a
           high-likelihood judgement built on thin sourcing is a different thing from one built on
           strong sourcing).
         </p>
         <p>
-          This is the <Link href="/knowledge/statistics">statistics</Link> lesson of being honest about
-          uncertainty, turned into disciplined language. Calibrated wording — neither falsely precise
-          nor uselessly hedged — is what lets a decision-maker weigh the assessment correctly.
+          This is the <Link href="/knowledge/statistics">statistics</Link> lesson of being honest
+          about uncertainty, turned into disciplined language. Calibrated wording — neither falsely
+          precise nor uselessly hedged — is what lets a decision-maker weigh the assessment
+          correctly.
         </p>
       </KSection>
 
       <KSection id="ethics" eyebrow="08" title="Probity and the law">
         <p>
-          Intelligence work, especially in government and policing, runs inside hard ethical and legal
-          limits. Collection must be <Term>lawful and proportionate</Term>; handling must respect{" "}
-          <Link href="/knowledge/data-governance">privacy and governance</Link>; and the analyst
-          carries a duty of <Term>probity</Term> — being honest, impartial, and rigorous, precisely
-          because the assessments can affect people's lives and liberty. The discipline isn't only
-          about being <em>right</em>; it's about being right in a way that's defensible, traceable, and
-          fair.
+          Intelligence work, especially in government and policing, runs inside hard ethical and
+          legal limits. Collection must be <Term>lawful and proportionate</Term>; handling must
+          respect <Link href="/knowledge/data-governance">privacy and governance</Link>; and the
+          analyst carries a duty of <Term>probity</Term> — being honest, impartial, and rigorous,
+          precisely because the assessments can affect people's lives and liberty. The discipline
+          isn't only about being <em>right</em>; it's about being right in a way that's defensible,
+          traceable, and fair.
         </p>
       </KSection>
 
@@ -233,19 +272,21 @@ function EnBody() {
         <Callout type="applied" label="The core of the current role">
           <p>
             This is the centre of what I do now. As a senior analyst in a government
-            professional-standards setting, the work is exactly this: turn incomplete information into
-            a defensible assessment for a decision-maker, under real constraints. The discipline on
-            this page is the daily practice — <strong>guarding against my own bias</strong> with
-            structured techniques like <strong>ACH</strong>, <strong>grading sources</strong> rather
-            than trusting them, keeping <strong>reporting separate from interpretation</strong>, and
-            being <strong>calibrated and lawful</strong> about what I can actually conclude.
+            professional-standards setting, the work is exactly this: turn incomplete information
+            into a defensible assessment for a decision-maker, under real constraints. The
+            discipline on this page is the daily practice —{" "}
+            <strong>guarding against my own bias</strong> with structured techniques like{" "}
+            <strong>ACH</strong>, <strong>grading sources</strong> rather than trusting them,
+            keeping <strong>reporting separate from interpretation</strong>, and being{" "}
+            <strong>calibrated and lawful</strong> about what I can actually conclude.
           </p>
           <p>
             It's where the rest of the section comes together in service of a decision: the{" "}
             <Link href="/knowledge/statistics">statistics</Link> for honest uncertainty, the{" "}
             <Link href="/knowledge/geospatial-analysis">spatial analysis</Link> for the "where", the{" "}
-            <Link href="/knowledge/science-communication">communication</Link> for the hand-off — all
-            pointed at the same target: a sound, defensible judgement that helps someone decide well.
+            <Link href="/knowledge/science-communication">communication</Link> for the hand-off —
+            all pointed at the same target: a sound, defensible judgement that helps someone decide
+            well.
           </p>
         </Callout>
       </KSection>
@@ -258,8 +299,8 @@ function EnBody() {
               Judged on usefulness, not cleverness.
             </li>
             <li>
-              The <strong>intelligence cycle</strong> (direction → collection → processing → analysis →
-              dissemination) is a loop tied to the decision-maker's need.
+              The <strong>intelligence cycle</strong> (direction → collection → processing →
+              analysis → dissemination) is a loop tied to the decision-maker's need.
             </li>
             <li>
               The real enemy is your own <strong>cognitive bias</strong> (confirmation, anchoring,
@@ -309,10 +350,10 @@ function ZhBody() {
 
       <KSection id="what" eyebrow="01" title="附着着一个决策的数据">
         <p>
-          情报的决定性特征是它的目的：它的存在是为了<strong>给一个具体的决策、给一个会据以行动的
-          具体的人提供信息</strong>。这使它区别于出于好奇而做的分析。一份情报产品被评判的，不是它
-          有多聪明，而是它有没有帮某人在不完美的信息下——在时间压力之下、带着后果——做出更好的
-          决断。
+          情报的决定性特征是它的目的：它的存在是为了
+          <strong>给一个具体的决策、给一个会据以行动的 具体的人提供信息</strong>
+          。这使它区别于出于好奇而做的分析。一份情报产品被评判的，不是它
+          有多聪明，而是它有没有帮某人在不完美的信息下——在时间压力之下、带着后果——做出更好的 决断。
         </p>
         <p>
           所以情报从根本上关乎<em>不确定性下的评估</em>。你几乎永远不会拥有全部事实；这份工作是从你
@@ -327,11 +368,21 @@ function ZhBody() {
           那个决策：
         </p>
         <ul>
-          <li><Term>方向</Term>——决策者究竟需要知道什么？驱动一切的需求。</li>
-          <li><Term>采集</Term>——从可用的来源收集相关信息。</li>
-          <li><Term>处理</Term>——把原始材料变成可用、有组织的形式。</li>
-          <li><Term>分析</Term>——核心：评估它意味着什么、权衡各种假设、形成一个判断。</li>
-          <li><Term>分发</Term>——把评估清晰、及时地交付给决策者。</li>
+          <li>
+            <Term>方向</Term>——决策者究竟需要知道什么？驱动一切的需求。
+          </li>
+          <li>
+            <Term>采集</Term>——从可用的来源收集相关信息。
+          </li>
+          <li>
+            <Term>处理</Term>——把原始材料变成可用、有组织的形式。
+          </li>
+          <li>
+            <Term>分析</Term>——核心：评估它意味着什么、权衡各种假设、形成一个判断。
+          </li>
+          <li>
+            <Term>分发</Term>——把评估清晰、及时地交付给决策者。
+          </li>
         </ul>
         <p>
           和<Link href="/knowledge/applied-data-science">数据科学生命周期</Link>一样，它是一个循环，
@@ -354,7 +405,8 @@ function ZhBody() {
           产品本身。
         </p>
         <p>
-          情报也常常从<em>不完整、不可靠</em>的信息出发推理，那里一个干净的数据集是你得不到的奢侈品。
+          情报也常常从<em>不完整、不可靠</em>
+          的信息出发推理，那里一个干净的数据集是你得不到的奢侈品。
           所以它较少依赖单一的数字，而更多依赖权衡相互竞争的解释、为每个来源能被信任多少分级，并对
           缺口直言不讳。本板块其余部分的定量工具箱当然有帮助——但核心技能是疑云之下的结构化推理。
         </p>
@@ -366,9 +418,15 @@ function ZhBody() {
           <Term>认知偏差</Term>。人的头脑会走捷径，那些捷径在草原上帮过我们，却在难题上背叛我们：
         </p>
         <ul>
-          <li><Term>确认偏差</Term>——只看到契合你既有理论的证据，而对其余打折扣。</li>
-          <li><Term>锚定</Term>——对你最先拿到的那条信息赋予过高的权重。</li>
-          <li><Term>过早收口</Term>——太早就定下一个答案、停止了搜寻。</li>
+          <li>
+            <Term>确认偏差</Term>——只看到契合你既有理论的证据，而对其余打折扣。
+          </li>
+          <li>
+            <Term>锚定</Term>——对你最先拿到的那条信息赋予过高的权重。
+          </li>
+          <li>
+            <Term>过早收口</Term>——太早就定下一个答案、停止了搜寻。
+          </li>
         </ul>
         <p>
           你无法靠更努力来关掉它们——意志力修不好一个线路问题。管用的是<em>方法</em>：迫使你去考虑
@@ -384,11 +442,13 @@ function ZhBody() {
         </p>
         <Callout type="intuition">
           <p>
-            <strong>竞争性假设分析（ACH）。</strong>你不去为你最钟意的解释构建论据，而是把<em>所有
-            </em>合理的假设在一开始就列出来，在一个矩阵里把每一条证据对照每一个假设摆开，并且——关键
-            在于——去寻找能<em>证伪</em>每一个假设的证据。胜出的不是支撑最多的那个假设；而是<em>反对
-            </em>它的证据最少的那个。ACH 通过逼你去尝试杀死你自己的理论，直接攻击确认偏差——与一个
-            好的<Link href="/knowledge/statistics">假设检验</Link>相同的证伪本能。
+            <strong>竞争性假设分析（ACH）。</strong>你不去为你最钟意的解释构建论据，而是把
+            <em>所有</em>
+            合理的假设在一开始就列出来，在一个矩阵里把每一条证据对照每一个假设摆开，并且——关键
+            在于——去寻找能<em>证伪</em>每一个假设的证据。胜出的不是支撑最多的那个假设；而是
+            <em>反对</em>它的证据最少的那个。ACH
+            通过逼你去尝试杀死你自己的理论，直接攻击确认偏差——与一个 好的
+            <Link href="/knowledge/statistics">假设检验</Link>相同的证伪本能。
           </p>
         </Callout>
         <p>
@@ -410,7 +470,8 @@ function ZhBody() {
           <em>可靠</em>（它的过往记录与获取渠道），以及这一条特定的信息有多<em>可信</em>（它是否契合
           其他已知之事、是否得到佐证）？一个可靠的来源仍可能传递一个可疑的说法，而一个不可靠的来源
           偶尔也会是对的——把这两种判断分开，才是这门纪律。跨独立来源相互佐证，把说法追溯到其源头，
-          并对<Term>核实</Term>问题保持警觉：同一个假故事在十个网站上回响，仍然是一条说法，而非十条。
+          并对<Term>核实</Term>
+          问题保持警觉：同一个假故事在十个网站上回响，仍然是一条说法，而非十条。
         </p>
       </KSection>
 
@@ -431,9 +492,10 @@ function ZhBody() {
 
       <KSection id="ethics" eyebrow="08" title="廉正与法律">
         <p>
-          情报工作，尤其在政府与警务中，运行在刚性的伦理与法律界限之内。采集必须<Term>合法且相称
-          </Term>；处理必须尊重<Link href="/knowledge/data-governance">隐私与治理</Link>；而分析师
-          肩负一份<Term>廉正</Term>的义务——诚实、公正、严谨，恰恰因为这些评估能影响到人的生命与
+          情报工作，尤其在政府与警务中，运行在刚性的伦理与法律界限之内。采集必须
+          <Term>合法且相称</Term>；处理必须尊重
+          <Link href="/knowledge/data-governance">隐私与治理</Link>；而分析师 肩负一份
+          <Term>廉正</Term>的义务——诚实、公正、严谨，恰恰因为这些评估能影响到人的生命与
           自由。这门纪律不只关乎<em>正确</em>；而关乎以一种可辩护、可追溯、公平的方式正确。
         </p>
       </KSection>
@@ -443,14 +505,16 @@ function ZhBody() {
           <p>
             这是我如今所做之事的中心。作为政府职业操守领域的一名高级分析师，工作正是这个：在真实的
             约束下，把不完整的信息变成一份可辩护、给决策者的评估。这一页上的纪律就是日常的实践——用
-            <strong>ACH</strong> 这样的结构化技术<strong>防范我自己的偏差</strong>、<strong>为来源
-            分级</strong>而非信任它们、把<strong>报告与解释分开</strong>，并对我究竟能下什么结论
+            <strong>ACH</strong> 这样的结构化技术<strong>防范我自己的偏差</strong>、
+            <strong>为来源 分级</strong>而非信任它们、把<strong>报告与解释分开</strong>
+            ，并对我究竟能下什么结论
             <strong>保持校准与合法</strong>。
           </p>
           <p>
-            这是本板块其余部分汇聚起来、服务于一个决策之处：<Link href="/knowledge/statistics">统计
-            </Link>用于诚实的不确定性、<Link href="/knowledge/geospatial-analysis">空间分析</Link>用于
-            「在哪里」、<Link href="/knowledge/science-communication">沟通</Link>用于交接——全都瞄准
+            这是本板块其余部分汇聚起来、服务于一个决策之处：
+            <Link href="/knowledge/statistics">统计</Link>用于诚实的不确定性、
+            <Link href="/knowledge/geospatial-analysis">空间分析</Link>用于 「在哪里」、
+            <Link href="/knowledge/science-communication">沟通</Link>用于交接——全都瞄准
             同一个目标：一个可靠、可辩护、帮某人决断得好的判断。
           </p>
         </Callout>
@@ -468,19 +532,20 @@ function ZhBody() {
               循环。
             </li>
             <li>
-              真正的敌人是你自己的<strong>认知偏差</strong>（确认、锚定、过早收口）——方法胜过意志力。
+              真正的敌人是你自己的<strong>认知偏差</strong>
+              （确认、锚定、过早收口）——方法胜过意志力。
             </li>
             <li>
-              <strong>结构化分析技术</strong>：<strong>ACH</strong>（列出所有假设、寻找证伪的证据）、
-              关键假设检查，以及把报告与解释分开。
+              <strong>结构化分析技术</strong>：<strong>ACH</strong>
+              （列出所有假设、寻找证伪的证据）、 关键假设检查，以及把报告与解释分开。
             </li>
             <li>
               <strong>OSINT</strong>：把<strong>来源可靠性</strong>与<strong>信息可信度</strong>分开
               分级；相互佐证；一个被回响的故事仍只是一条说法。
             </li>
             <li>
-              使用校准过的<strong>置信度语言</strong>（概率标尺），并以<strong>合法、相称、廉正
-              </strong>的方式工作。
+              使用校准过的<strong>置信度语言</strong>（概率标尺），并以
+              <strong>合法、相称、廉正</strong>的方式工作。
             </li>
           </ul>
         </Callout>

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
     "build": "next build --webpack",
     "start": "next start",
     "lint": "eslint .",
-    "format": "prettier --write \"**/*.{js,jsx,json,css,md}\" --ignore-path .gitignore",
-    "format:check": "prettier --check \"**/*.{js,jsx,json,css,md}\" --ignore-path .gitignore",
+    "format": "prettier --write \"**/*.{js,jsx,json,css,md}\" --ignore-path .gitignore --ignore-path .prettierignore",
+    "format:check": "prettier --check \"**/*.{js,jsx,json,css,md}\" --ignore-path .gitignore --ignore-path .prettierignore",
     "deploy": "vercel --prod"
   },
   "dependencies": {


### PR DESCRIPTION
Resolves the format follow-up from the CI work.

## What

- **`.prettierignore`** added (lockfile, generated `sw.js`, build output, agent tooling); `format`/`format:check` scripts now honour it alongside `.gitignore`.
- **One-time Prettier pass** — the source was already ~99% clean; only 2 components actually drifted (`anomaly-detection.jsx`, `intelligence-analysis.jsx`). The earlier "865 files" was untracked `.claude/`/`.agents/` tooling, not source.
- **Format gate is now blocking** — removed `continue-on-error` from the CI format job, so style drift fails the build.

No `.git-blame-ignore-revs` — a 2-file reformat doesn't pollute blame enough to warrant it.

## Verified locally

- `npm run lint` → 0 errors
- `npm run build` → green
- `npm run format:check` → clean on all tracked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)