### PR TITLE
chore: pre-commit auto-format hook + fix red format gate

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,1 @@
+npx lint-staged

--- a/components/knowledge/content/information-retrieval.jsx
+++ b/components/knowledge/content/information-retrieval.jsx
@@ -1,5 +1,12 @@
 import Link from "next/link";
-import { KSection, Callout, Formula, Figure, TeX, Term } from "@/components/knowledge/KnowledgeLayout";
+import {
+  KSection,
+  Callout,
+  Formula,
+  Figure,
+  TeX,
+  Term,
+} from "@/components/knowledge/KnowledgeLayout";
 
 /**
  * Per-locale content for /knowledge/information-retrieval.
@@ -27,26 +34,156 @@ function SparseDenseFigure({
         role="img"
         aria-label={ariaLabel}
       >
-        <rect x="180" y="12" width="80" height="24" rx="3" fill="none" stroke="currentColor" strokeWidth="1.3" />
-        <text x="220" y="28" textAnchor="middle" fontSize="9.5" fontFamily="monospace" fill="currentColor">{queryLabel}</text>
+        <rect
+          x="180"
+          y="12"
+          width="80"
+          height="24"
+          rx="3"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.3"
+        />
+        <text
+          x="220"
+          y="28"
+          textAnchor="middle"
+          fontSize="9.5"
+          fontFamily="monospace"
+          fill="currentColor"
+        >
+          {queryLabel}
+        </text>
         {/* sparse */}
-        <rect x="40" y="62" width="130" height="24" rx="3" fill="none" stroke="currentColor" strokeWidth="1.2" />
-        <text x="105" y="78" textAnchor="middle" fontSize="8.5" fontFamily="monospace" fill="currentColor">{sparseLabel}</text>
-        <text x="105" y="100" textAnchor="middle" fontSize="7.5" fontFamily="monospace" fill="currentColor" opacity="0.6">{sparseSub}</text>
-        <line x1="195" y1="36" x2="130" y2="62" stroke="currentColor" strokeWidth="1.1" markerEnd="url(#irah)" />
+        <rect
+          x="40"
+          y="62"
+          width="130"
+          height="24"
+          rx="3"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.2"
+        />
+        <text
+          x="105"
+          y="78"
+          textAnchor="middle"
+          fontSize="8.5"
+          fontFamily="monospace"
+          fill="currentColor"
+        >
+          {sparseLabel}
+        </text>
+        <text
+          x="105"
+          y="100"
+          textAnchor="middle"
+          fontSize="7.5"
+          fontFamily="monospace"
+          fill="currentColor"
+          opacity="0.6"
+        >
+          {sparseSub}
+        </text>
+        <line
+          x1="195"
+          y1="36"
+          x2="130"
+          y2="62"
+          stroke="currentColor"
+          strokeWidth="1.1"
+          markerEnd="url(#irah)"
+        />
         {/* dense */}
-        <rect x="270" y="62" width="130" height="24" rx="3" fill="none" stroke="#FF3C3C" strokeWidth="1.3" />
-        <text x="335" y="78" textAnchor="middle" fontSize="8.5" fontFamily="monospace" fill="#FF3C3C">{denseLabel}</text>
-        <text x="335" y="100" textAnchor="middle" fontSize="7.5" fontFamily="monospace" fill="currentColor" opacity="0.6">{denseSub}</text>
-        <line x1="245" y1="36" x2="310" y2="62" stroke="#FF3C3C" strokeWidth="1.1" markerEnd="url(#irahr)" />
+        <rect
+          x="270"
+          y="62"
+          width="130"
+          height="24"
+          rx="3"
+          fill="none"
+          stroke="#FF3C3C"
+          strokeWidth="1.3"
+        />
+        <text
+          x="335"
+          y="78"
+          textAnchor="middle"
+          fontSize="8.5"
+          fontFamily="monospace"
+          fill="#FF3C3C"
+        >
+          {denseLabel}
+        </text>
+        <text
+          x="335"
+          y="100"
+          textAnchor="middle"
+          fontSize="7.5"
+          fontFamily="monospace"
+          fill="currentColor"
+          opacity="0.6"
+        >
+          {denseSub}
+        </text>
+        <line
+          x1="245"
+          y1="36"
+          x2="310"
+          y2="62"
+          stroke="#FF3C3C"
+          strokeWidth="1.1"
+          markerEnd="url(#irahr)"
+        />
         {/* hybrid */}
-        <rect x="170" y="116" width="100" height="24" rx="3" fill="none" stroke="currentColor" strokeWidth="1.4" />
-        <text x="220" y="132" textAnchor="middle" fontSize="9" fontFamily="monospace" fill="currentColor">{hybridLabel}</text>
-        <line x1="105" y1="86" x2="185" y2="116" stroke="currentColor" strokeWidth="1" opacity="0.6" markerEnd="url(#irah)" />
-        <line x1="335" y1="86" x2="255" y2="116" stroke="#FF3C3C" strokeWidth="1" opacity="0.6" markerEnd="url(#irahr)" />
+        <rect
+          x="170"
+          y="116"
+          width="100"
+          height="24"
+          rx="3"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth="1.4"
+        />
+        <text
+          x="220"
+          y="132"
+          textAnchor="middle"
+          fontSize="9"
+          fontFamily="monospace"
+          fill="currentColor"
+        >
+          {hybridLabel}
+        </text>
+        <line
+          x1="105"
+          y1="86"
+          x2="185"
+          y2="116"
+          stroke="currentColor"
+          strokeWidth="1"
+          opacity="0.6"
+          markerEnd="url(#irah)"
+        />
+        <line
+          x1="335"
+          y1="86"
+          x2="255"
+          y2="116"
+          stroke="#FF3C3C"
+          strokeWidth="1"
+          opacity="0.6"
+          markerEnd="url(#irahr)"
+        />
         <defs>
-          <marker id="irah" markerWidth="7" markerHeight="7" refX="6" refY="2.5" orient="auto"><path d="M0,0 L6,2.5 L0,5 Z" fill="currentColor" /></marker>
-          <marker id="irahr" markerWidth="7" markerHeight="7" refX="6" refY="2.5" orient="auto"><path d="M0,0 L6,2.5 L0,5 Z" fill="#FF3C3C" /></marker>
+          <marker id="irah" markerWidth="7" markerHeight="7" refX="6" refY="2.5" orient="auto">
+            <path d="M0,0 L6,2.5 L0,5 Z" fill="currentColor" />
+          </marker>
+          <marker id="irahr" markerWidth="7" markerHeight="7" refX="6" refY="2.5" orient="auto">
+            <path d="M0,0 L6,2.5 L0,5 Z" fill="#FF3C3C" />
+          </marker>
         </defs>
       </svg>
     </Figure>
@@ -293,16 +430,18 @@ function ZhBody() {
       </p>
       <p>
         这一页是那片干活的地景：搜索如何被做快、经典排序如何运作（以及至今仍静悄悄驱动着大多数搜索框的
-        BM25 函数）、你如何测量结果好不好，以及转向语义搜索——它弥合了经典方法永远够不到的那道鸿沟。它
+        BM25
+        函数）、你如何测量结果好不好，以及转向语义搜索——它弥合了经典方法永远够不到的那道鸿沟。它
         建立在 <Link href="/knowledge/natural-language-processing">NLP</Link> 页之上，并连到
         <Link href="/knowledge/recommender-systems">推荐系统</Link>——两者都是排序问题。
       </p>
 
       <KSection id="problem" eyebrow="01" title="大海捞针">
         <p>
-          IR 问题：给定一个<Term>查询</Term>和一个庞大的文档<Term>语料库</Term>，返回那些<em>按与该
-          查询的相关性排序</em>的文档。有两样东西让它变难。第一，<strong>规模</strong>——你没法为每个
-          查询读每一份文档，所以你需要一个能快速找出候选的结构。第二，<strong>相关性</strong>——「相关」
+          IR 问题：给定一个<Term>查询</Term>和一个庞大的文档<Term>语料库</Term>，返回那些
+          <em>按与该 查询的相关性排序</em>的文档。有两样东西让它变难。第一，<strong>规模</strong>
+          ——你没法为每个 查询读每一份文档，所以你需要一个能快速找出候选的结构。第二，
+          <strong>相关性</strong>——「相关」
           是模糊而属于人的，把几个查询词变成一个好的排序，正是全部的艺术。这个领域分两个阶段对付它们：
           一个快速的结构来取回候选，然后一个排序函数来给它们排序。
         </p>
@@ -357,8 +496,8 @@ function ZhBody() {
         <ul>
           <li>
             <Term>词频饱和</Term>——一个出现 100 次的词，并不比出现一次相关 100 倍。
-            <TeX>{String.raw`k_1`}</TeX> 项让贡献<em>饱和</em>，于是额外的重复添加得越来越少。（朴素的
-            TF-IDF 会永远线性增长。）
+            <TeX>{String.raw`k_1`}</TeX> 项让贡献<em>饱和</em>
+            ，于是额外的重复添加得越来越少。（朴素的 TF-IDF 会永远线性增长。）
           </li>
           <li>
             <Term>长度归一化</Term>——长文档自然含有更多的词，这会不公平地抬高它们的分数。
@@ -373,19 +512,21 @@ function ZhBody() {
 
       <KSection id="metrics" eyebrow="05" title="测量相关性">
         <p>
-          你怎么知道你的排序好不好？IR 有它自己的<Link href="/knowledge/model-evaluation">评估</Link>
+          你怎么知道你的排序好不好？IR 有它自己的
+          <Link href="/knowledge/model-evaluation">评估</Link>
           指标，而相比分类的关键转变在于<strong>顺序要紧</strong>——一个排在第 1 位的相关结果，远比
           同样的结果排在第 50 位值钱得多。除了在前 k 个上朴素的
-          <Link href="/knowledge/statistics">精确率与召回率</Link>，主力是 <Term>MAP</Term>（平均精度
-          均值）与 <Term>NDCG</Term>（归一化折损累积增益），它们奖励把<em>最</em>相关的结果放<em>最
-          </em>高——这与<Link href="/knowledge/recommender-systems">推荐系统</Link>里的排序质量想法相同，
-          因为两者本质上都是「把列表排好」的问题。
+          <Link href="/knowledge/statistics">精确率与召回率</Link>，主力是 <Term>MAP</Term>
+          （平均精度 均值）与 <Term>NDCG</Term>（归一化折损累积增益），它们奖励把<em>最</em>
+          相关的结果放<em>最</em>高——这与<Link href="/knowledge/recommender-systems">推荐系统</Link>
+          里的排序质量想法相同， 因为两者本质上都是「把列表排好」的问题。
         </p>
       </KSection>
 
       <KSection id="gap" eyebrow="06" title="词汇鸿沟">
         <p>
-          尽管有种种长处，经典的关键词搜索（BM25 也包括在内）有一个根本的盲点：它匹配<em>词</em>，而非
+          尽管有种种长处，经典的关键词搜索（BM25 也包括在内）有一个根本的盲点：它匹配<em>词</em>
+          ，而非
           <em>含义</em>。搜「car（汽车）」，而一份只说「automobile（机动车）」的文档得分为零——没有
           共享的词项、没有匹配，尽管含义完全相同。这道<Term>词汇鸿沟</Term>（词汇失配）是词法方法的
           天花板：同义词、改述、相关的概念，对一个只数精确词重叠的系统来说都是看不见的。弥合它需要理解
@@ -395,7 +536,8 @@ function ZhBody() {
 
       <KSection id="dense" eyebrow="07" title="语义搜索：稠密检索">
         <p>
-          现代的答案是<Term>稠密检索</Term>。它不用稀疏的词数向量，而是把查询和每一份文档编码成稠密的
+          现代的答案是<Term>稠密检索</Term>
+          。它不用稀疏的词数向量，而是把查询和每一份文档编码成稠密的
           <Link href="/knowledge/natural-language-processing">嵌入</Link>——捕获<em>含义</em>的向量，
           于是「car」与「automobile」落得很近。检索于是变成在那个语义空间里，找出离查询向量最近的那些
           文档向量，这一跃就越过了词汇鸿沟：它在概念上匹配，而非关键词。
@@ -411,11 +553,13 @@ function ZhBody() {
           hybridLabel="混合（融合）"
         />
         <p>
-          稠密检索需要<Term>近似最近邻</Term>搜索（像 HNSW 这样的算法、像 FAISS 这样的库）才能在数百万
-          个向量中快速找出相近的，而它比 BM25 更沉重、在精确词项（名字、代码、罕见行话）上也更不精确。
-          所以现代的最佳实践是<Term>混合搜索</Term>：稀疏<em>和</em>稠密都跑、融合排序，可选地在最靠前的
-          结果上再加一个神经<Term>重排器</Term>。这个「先检索再排序」的流水线，正是 <strong>RAG 里的 R
-          </strong>——那个把一个<Link href="/knowledge/deep-learning">大语言模型</Link>锚定在真实文档、
+          稠密检索需要<Term>近似最近邻</Term>搜索（像 HNSW 这样的算法、像 FAISS
+          这样的库）才能在数百万 个向量中快速找出相近的，而它比 BM25
+          更沉重、在精确词项（名字、代码、罕见行话）上也更不精确。 所以现代的最佳实践是
+          <Term>混合搜索</Term>：稀疏<em>和</em>稠密都跑、融合排序，可选地在最靠前的
+          结果上再加一个神经<Term>重排器</Term>。这个「先检索再排序」的流水线，正是{" "}
+          <strong>RAG 里的 R</strong>——那个把一个
+          <Link href="/knowledge/deep-learning">大语言模型</Link>锚定在真实文档、
           而非它的记忆里的检索步骤，这就是为什么有数十年历史的 IR，忽然来到了现代 AI 的中心。
         </p>
       </KSection>
@@ -424,15 +568,17 @@ function ZhBody() {
         <Callout type="applied" label="把草垛搜索好">
           <p>
             许多情报与分析工作，都始于 IR 所解决的那同一个问题：在一个非常大的集合里找出相关的文档。
-            知道搜索实际上如何排序，改变了我使用它的方式——理解 <strong>BM25</strong>（它匹配精确词项、
-            奖励罕见而有辨识度的词）解释了一个查询为什么成功或失败，而知道<strong>词汇鸿沟</strong>解释
+            知道搜索实际上如何排序，改变了我使用它的方式——理解 <strong>BM25</strong>
+            （它匹配精确词项、 奖励罕见而有辨识度的词）解释了一个查询为什么成功或失败，而知道
+            <strong>词汇鸿沟</strong>解释
             了一个关键词搜索为什么会漏掉一份用了同义词的文档，而那恰恰是会丢失重要材料的盲点。
           </p>
           <p>
-            它也越来越实用：<strong>语义/稠密检索</strong>与<strong>混合搜索</strong>，是你找到关键词
-            搜索找不到的、概念上相关的材料的方式，而<strong>先检索再排序</strong>的流水线，是正进入
-            工具箱的 <Link href="/knowledge/deep-learning">LLM</Link> 驱动工具（RAG）底下的引擎。它直接
-            连到 <Link href="/knowledge/natural-language-processing">NLP</Link>（那些嵌入）、
+            它也越来越实用：<strong>语义/稠密检索</strong>与<strong>混合搜索</strong>
+            ，是你找到关键词 搜索找不到的、概念上相关的材料的方式，而<strong>先检索再排序</strong>
+            的流水线，是正进入 工具箱的 <Link href="/knowledge/deep-learning">LLM</Link>{" "}
+            驱动工具（RAG）底下的引擎。它直接 连到{" "}
+            <Link href="/knowledge/natural-language-processing">NLP</Link>（那些嵌入）、
             <Link href="/knowledge/recommender-systems">推荐系统</Link>（排序），以及
             <Link href="/knowledge/intelligence-analysis">OSINT</Link>（搜索开源的草垛）。
           </p>
@@ -450,9 +596,9 @@ function ZhBody() {
               <strong>倒排索引</strong>（「词 → 文档」）让搜索变快——查出查询词，只给候选打分。
             </li>
             <li>
-              <strong>TF-IDF</strong> 给词项加权（在文档里频繁 × 在语料里罕见）。<strong>BM25</strong> 用
-              <strong>词频饱和</strong>（重复越发不重要）+ <strong>长度归一化</strong>改进它——仍是一个
-              难缠的基线。
+              <strong>TF-IDF</strong> 给词项加权（在文档里频繁 × 在语料里罕见）。
+              <strong>BM25</strong> 用<strong>词频饱和</strong>（重复越发不重要）+{" "}
+              <strong>长度归一化</strong>改进它——仍是一个 难缠的基线。
             </li>
             <li>
               用排序指标评估——<strong>顺序要紧</strong>：MAP、NDCG（与推荐系统相同）。

--- a/components/knowledge/content/knowledge-graphs.jsx
+++ b/components/knowledge/content/knowledge-graphs.jsx
@@ -27,18 +27,90 @@ function TriplesGraphFigure({ caption, ariaLabel }) {
       >
         {KG_NODES.map(([t, cx, cy], i) => (
           <g key={i}>
-            <circle cx={cx} cy={cy} r="22" fill="none" stroke={i === 1 ? "#FF3C3C" : "currentColor"} strokeWidth="1.4" />
-            <text x={cx} y={cy + 3} textAnchor="middle" fontSize="8.5" fontFamily="monospace" fill="currentColor">{t}</text>
+            <circle
+              cx={cx}
+              cy={cy}
+              r="22"
+              fill="none"
+              stroke={i === 1 ? "#FF3C3C" : "currentColor"}
+              strokeWidth="1.4"
+            />
+            <text
+              x={cx}
+              y={cy + 3}
+              textAnchor="middle"
+              fontSize="8.5"
+              fontFamily="monospace"
+              fill="currentColor"
+            >
+              {t}
+            </text>
           </g>
         ))}
-        <line x1="72" y1="65" x2="149" y2="45" stroke="currentColor" strokeWidth="1.1" markerEnd="url(#kgah)" />
-        <text x="105" y="48" textAnchor="middle" fontSize="7" fontFamily="monospace" fill="currentColor" opacity="0.7">works_for</text>
-        <line x1="191" y1="48" x2="280" y2="72" stroke="currentColor" strokeWidth="1.1" markerEnd="url(#kgah)" />
-        <text x="232" y="56" textAnchor="middle" fontSize="7" fontFamily="monospace" fill="currentColor" opacity="0.7">hq_in</text>
-        <line x1="322" y1="72" x2="390" y2="50" stroke="currentColor" strokeWidth="1.1" markerEnd="url(#kgah)" />
-        <text x="360" y="56" textAnchor="middle" fontSize="7" fontFamily="monospace" fill="currentColor" opacity="0.7">located_in</text>
+        <line
+          x1="72"
+          y1="65"
+          x2="149"
+          y2="45"
+          stroke="currentColor"
+          strokeWidth="1.1"
+          markerEnd="url(#kgah)"
+        />
+        <text
+          x="105"
+          y="48"
+          textAnchor="middle"
+          fontSize="7"
+          fontFamily="monospace"
+          fill="currentColor"
+          opacity="0.7"
+        >
+          works_for
+        </text>
+        <line
+          x1="191"
+          y1="48"
+          x2="280"
+          y2="72"
+          stroke="currentColor"
+          strokeWidth="1.1"
+          markerEnd="url(#kgah)"
+        />
+        <text
+          x="232"
+          y="56"
+          textAnchor="middle"
+          fontSize="7"
+          fontFamily="monospace"
+          fill="currentColor"
+          opacity="0.7"
+        >
+          hq_in
+        </text>
+        <line
+          x1="322"
+          y1="72"
+          x2="390"
+          y2="50"
+          stroke="currentColor"
+          strokeWidth="1.1"
+          markerEnd="url(#kgah)"
+        />
+        <text
+          x="360"
+          y="56"
+          textAnchor="middle"
+          fontSize="7"
+          fontFamily="monospace"
+          fill="currentColor"
+          opacity="0.7"
+        >
+          located_in
+        </text>
         <defs>
-          <marker id="kgah" markerWidth="7" markerHeight="7" refX="6" refY="2.5" orient="auto"><path d="M0,0 L6,2.5 L0,5 Z" fill="currentColor" /></marker>
+          <marker id="kgah" markerWidth="7" markerHeight="7" refX="6" refY="2.5" orient="auto">
+            <path d="M0,0 L6,2.5 L0,5 Z" fill="currentColor" />
+          </marker>
         </defs>
       </svg>
     </Figure>
@@ -268,23 +340,27 @@ function ZhBody() {
     <>
       <p>
         大多数数据住在表里——整齐的行与列，一物一条记录。但我们真正想知道的，有很大一部分是关于
-        <em>关系</em>的：谁为谁工作、哪家公司拥有哪家、这个账户如何与那个人相连。表处理这个很别扭（没
-        完没了的连接，还有些问题你根本没法表述）。一个<Term>知识图谱</Term>按信息自然连接的方式来存储
-        它——作为一张由<em>关系</em>连接起来的<em>实体</em>之网——把「一切如何关联？」从一个痛苦的查询，
-        变成一个自然的查询。
+        <em>关系</em>
+        的：谁为谁工作、哪家公司拥有哪家、这个账户如何与那个人相连。表处理这个很别扭（没
+        完没了的连接，还有些问题你根本没法表述）。一个<Term>知识图谱</Term>
+        按信息自然连接的方式来存储 它——作为一张由<em>关系</em>连接起来的<em>实体</em>
+        之网——把「一切如何关联？」从一个痛苦的查询， 变成一个自然的查询。
       </p>
       <p>
         它是<Link href="/knowledge/network-graph-analysis">网络分析</Link>页那个结构化的、讲事实的
-        表亲（那一页研究一张网络的<em>形状</em>；这一页则关于存储与查询<em>意义</em>），并且正越来越成为
-        把 <Link href="/knowledge/large-language-models">AI 系统</Link>锚定在真实事实上的骨干。这一页是
+        表亲（那一页研究一张网络的<em>形状</em>；这一页则关于存储与查询<em>意义</em>
+        ），并且正越来越成为 把 <Link href="/knowledge/large-language-models">AI 系统</Link>
+        锚定在真实事实上的骨干。这一页是
         那个实用的想法：事实如何变成一张图、它如何被构建与查询，以及它在哪里有回报——又在哪里有代价。
       </p>
 
       <KSection id="why" eyebrow="01" title="把事实当作一张图">
         <p>
-          表示方式的转变正是全部的重点。在一张表里，「Acme 公司总部在阿德莱德」是某一行里的一个单元格；
+          表示方式的转变正是全部的重点。在一张表里，「Acme
+          公司总部在阿德莱德」是某一行里的一个单元格；
           它与「阿德莱德在南澳」之间的连接住在另一张表里，把它们绑在一起意味着一次连接。在一个知识
-          图谱里，<em>Acme</em>、<em>阿德莱德</em>、<em>南澳</em>全都是节点，由带标签的边直接相连——而从
+          图谱里，<em>Acme</em>、<em>阿德莱德</em>、<em>南澳</em>
+          全都是节点，由带标签的边直接相连——而从
           一家公司沿链条走到它所在的州，不过是走两条边。关系是一等公民的数据，而不是你按需重建的东西。
         </p>
       </KSection>
@@ -292,8 +368,9 @@ function ZhBody() {
       <KSection id="triples" eyebrow="02" title="三元组：知识的原子">
         <p>
           基本单位是<Term>三元组</Term>：一个单一的事实，表达为<strong>主语 → 谓语 → 宾语</strong>。
-          「Acme → headquartered_in → 阿德莱德。」「阿德莱德 → located_in → 南澳。」「Jane → works_for
-          → Acme。」每个三元组都是两个节点之间的一条边，而一整张知识图谱不过是这些三元组的一大堆——
+          「Acme → headquartered_in → 阿德莱德。」「阿德莱德 → located_in → 南澳。」「Jane →
+          works_for →
+          Acme。」每个三元组都是两个节点之间的一条边，而一整张知识图谱不过是这些三元组的一大堆——
           数百万乃至数十亿个——编织成一张相互连接的网。
         </p>
         <TriplesGraphFigure
@@ -302,20 +379,24 @@ function ZhBody() {
         />
         <p>
           这就是 <Term>Wikidata</Term> 存储维基百科背后结构化知识的方式，也是谷歌的
-          <Term>知识图谱</Term>驱动其搜索结果旁那些事实框的方式。三元组很简单，但在规模上它表达力惊人。
+          <Term>知识图谱</Term>
+          驱动其搜索结果旁那些事实框的方式。三元组很简单，但在规模上它表达力惊人。
         </p>
       </KSection>
 
       <KSection id="ontology" eyebrow="03" title="本体：约定的词汇表">
         <p>
-          只有当所有人都同意实体和关系<em>类型</em>是什么意思时，一堆三元组才是连贯的。那个约定的词汇表
-          就是<Term>本体</Term>（或模式）：它定义了事物的类别（人、组织、地点）以及它们之间有效的关系
-          （一个人可以 <em>work_for</em> 一个组织；一个组织可以 <em>headquartered_in</em> 一个地点）。
-          漂亮的说法是：<strong>数据 + 一个本体 = 一个知识图谱</strong>——本体正是那个告诉机器每个节点和
-          边实际上<em>是</em>什么的东西，把图从一团字符串提升为一个有意义的结构。
+          只有当所有人都同意实体和关系<em>类型</em>
+          是什么意思时，一堆三元组才是连贯的。那个约定的词汇表 就是<Term>本体</Term>
+          （或模式）：它定义了事物的类别（人、组织、地点）以及它们之间有效的关系 （一个人可以{" "}
+          <em>work_for</em> 一个组织；一个组织可以 <em>headquartered_in</em> 一个地点）。
+          漂亮的说法是：<strong>数据 + 一个本体 = 一个知识图谱</strong>
+          ——本体正是那个告诉机器每个节点和 边实际上<em>是</em>
+          什么的东西，把图从一团字符串提升为一个有意义的结构。
         </p>
         <p>
-          本体也是让你能<strong>统一异构来源</strong>的东西：把两个不同的数据库映射到同一个共享的词汇表
+          本体也是让你能<strong>统一异构来源</strong>
+          的东西：把两个不同的数据库映射到同一个共享的词汇表
           上，它们的事实就合并成一张相互连接的图，即便它们原本用不同的名字称呼同一样东西。
         </p>
       </KSection>
@@ -324,17 +405,18 @@ function ZhBody() {
         <p>从真实而杂乱的来源构建一个知识图谱，正是真正的困难所在，而它倚靠本板块各处的工具：</p>
         <ul>
           <li>
-            <Term>实体与关系抽取</Term>——从非结构化文本里抽出结构化的三元组（一份说「Jane 加入了 Acme」
-            的报告 → 那个 <em>works_for</em> 三元组）。这是一个
+            <Term>实体与关系抽取</Term>——从非结构化文本里抽出结构化的三元组（一份说「Jane 加入了
+            Acme」 的报告 → 那个 <em>works_for</em> 三元组）。这是一个
             <Link href="/knowledge/natural-language-processing">NLP</Link> 任务，越来越多地用
             <Link href="/knowledge/large-language-models">LLM</Link> 来做。
           </li>
           <li>
-            <Term>实体消解</Term>——关键所在。「J. Smith」「Jane Smith」和「Smith, J.」可能是一个人、也
+            <Term>实体消解</Term>——关键所在。「J. Smith」「Jane Smith」和「Smith,
+            J.」可能是一个人、也
             可能是三个，而图的好坏只取决于它判断这个的能力。把这个弄错，会把一个实体<em>碎裂</em>成
             许多个、或把不同的实体<em>混为一谈</em>——与
-            <Link href="/knowledge/feature-engineering">数据准备</Link>页同样的记录链接问题，只是赌注
-            更高，因为错误会腐蚀整个相互连接的结构。
+            <Link href="/knowledge/feature-engineering">数据准备</Link>
+            页同样的记录链接问题，只是赌注 更高，因为错误会腐蚀整个相互连接的结构。
           </li>
         </ul>
         <p>
@@ -345,26 +427,30 @@ function ZhBody() {
 
       <KSection id="query" eyebrow="05" title="查询：表回答不了的问题">
         <p>
-          回报在于那些查询。图查询语言（用于 RDF 图的 <Term>SPARQL</Term>、用于属性图的 Cypher）让你能
-          问那些遍历关系的<Term>多跳</Term>问题——正是表所吃力的那些问题。「Jane 工作过的那些公司的
-          供应商里，有哪些设在海外？」是一次自然的图遍历（Jane → 公司 → 它们的供应商 → 按地点过滤），但
-          在 SQL 里却是一场连接的噩梦。
+          回报在于那些查询。图查询语言（用于 RDF 图的 <Term>SPARQL</Term>、用于属性图的
+          Cypher）让你能 问那些遍历关系的<Term>多跳</Term>问题——正是表所吃力的那些问题。「Jane
+          工作过的那些公司的 供应商里，有哪些设在海外？」是一次自然的图遍历（Jane → 公司 →
+          它们的供应商 → 按地点过滤），但 在 SQL 里却是一场连接的噩梦。
         </p>
         <p>
-          这才是去拿一个知识图谱的真正理由：当<em>连接</em>本身就是那个问题时。在许多关系上找出链条、
-          路径、以及间接的链接，正是这个结构所为之而建的——也是<Link href="/knowledge/network-graph-analysis">
-          网络分析</Link>的那些度量（中心性、社区、链接预测）随后可以叠加在上面的地方。
+          这才是去拿一个知识图谱的真正理由：当<em>连接</em>
+          本身就是那个问题时。在许多关系上找出链条、
+          路径、以及间接的链接，正是这个结构所为之而建的——也是
+          <Link href="/knowledge/network-graph-analysis">网络分析</Link>
+          的那些度量（中心性、社区、链接预测）随后可以叠加在上面的地方。
         </p>
       </KSection>
 
       <KSection id="graphrag" eyebrow="06" title="知识图谱 + LLM：GraphRAG">
         <p>
-          知识图谱最新的角色，是为<Link href="/knowledge/large-language-models">大语言模型</Link>提供
-          锚定。普通的 <Link href="/knowledge/information-retrieval">RAG</Link> 取回文本段落，而
-          <Term>GraphRAG</Term> 从一个知识图谱里取回<em>结构化的事实及其连接</em>，喂给 LLM。因为那些
-          事实是明确的、带类型的、可追溯的，这能大幅减少
+          知识图谱最新的角色，是为<Link href="/knowledge/large-language-models">大语言模型</Link>
+          提供 锚定。普通的 <Link href="/knowledge/information-retrieval">RAG</Link>{" "}
+          取回文本段落，而
+          <Term>GraphRAG</Term> 从一个知识图谱里取回<em>结构化的事实及其连接</em>，喂给
+          LLM。因为那些 事实是明确的、带类型的、可追溯的，这能大幅减少
           <Link href="/knowledge/large-language-models">幻觉</Link>、并回答 LLM 否则会糊弄过去的多跳
-          问题——图提供可验证的结构，LLM 在其上提供流畅的语言。它是一个迅速兴起的模式，恰恰因为它把每个
+          问题——图提供可验证的结构，LLM
+          在其上提供流畅的语言。它是一个迅速兴起的模式，恰恰因为它把每个
           系统的长处，去对上另一个的短处。
         </p>
       </KSection>
@@ -374,9 +460,11 @@ function ZhBody() {
         <Callout type="pitfall">
           <p>
             <strong>构建很昂贵</strong>——构建、以及更难的<em>维护</em>一个高质量的图，是一项严肃的、
-            持续的努力，而非一锤子买卖。<strong>实体消解的错误</strong>会悄悄腐蚀它（一个合并错或拆分错
-            的实体，会毒害每一个碰到它的查询）。它会随着世界的变化而<strong>变陈旧</strong>（曾经为真的
-            事实变成假的）。而且<strong>本体可能太僵硬</strong>——真实的知识比一个固定的模式所承认的更
+            持续的努力，而非一锤子买卖。<strong>实体消解的错误</strong>
+            会悄悄腐蚀它（一个合并错或拆分错
+            的实体，会毒害每一个碰到它的查询）。它会随着世界的变化而<strong>变陈旧</strong>
+            （曾经为真的 事实变成假的）。而且<strong>本体可能太僵硬</strong>
+            ——真实的知识比一个固定的模式所承认的更
             杂乱、更有争议，而硬把它塞进去会丢失细微差别。当关系真正是工作的核心时，一个知识图谱才值得；
             而当一张表就够用时，它就杀鸡用牛刀了。
           </p>
@@ -387,17 +475,20 @@ function ZhBody() {
         <Callout type="applied" label="由散落的事实拼成的可查询图景">
           <p>
             在情报工作里，核心任务往往恰恰是知识图谱为之而建的：把实体——人、组织、账户、事件——跨许多
-            散落的来源<strong>链接成一幅相互连接的、可查询的图景</strong>，然后追问它们如何关联。那些
-            <strong>多跳</strong>问题（「谁通过哪些组织与这个人相连？」）才是要紧的、也是表不能轻易回答
-            的。
+            散落的来源<strong>链接成一幅相互连接的、可查询的图景</strong>
+            ，然后追问它们如何关联。那些
+            <strong>多跳</strong>
+            问题（「谁通过哪些组织与这个人相连？」）才是要紧的、也是表不能轻易回答 的。
           </p>
           <p>
-            我紧抓不放的是：价值的存亡系于<strong>实体消解</strong>——把「这是同一个人吗？」做对，正是
+            我紧抓不放的是：价值的存亡系于<strong>实体消解</strong>
+            ——把「这是同一个人吗？」做对，正是
             一张澄清问题的图与一张误导人的图之间的差别——以及这个结构直接喂入
-            <Link href="/knowledge/network-graph-analysis">网络分析</Link>（在图之上的中心性、社区）、
-            并喂入 <strong>GraphRAG</strong> 以把 <Link href="/knowledge/large-language-models">LLM</Link>
-            工具锚定在可验证的事实上。它也与<Link href="/knowledge/data-governance">治理</Link>相配：一张
-            谁-关联-什么的图很强大，因而要求对访问与准确性多加小心。
+            <Link href="/knowledge/network-graph-analysis">网络分析</Link>
+            （在图之上的中心性、社区）、 并喂入 <strong>GraphRAG</strong> 以把{" "}
+            <Link href="/knowledge/large-language-models">LLM</Link>
+            工具锚定在可验证的事实上。它也与<Link href="/knowledge/data-governance">治理</Link>
+            相配：一张 谁-关联-什么的图很强大，因而要求对访问与准确性多加小心。
           </p>
         </Callout>
       </KSection>
@@ -406,28 +497,28 @@ function ZhBody() {
         <Callout type="refresher">
           <ul className="list-disc pl-5 space-y-2">
             <li>
-              一个知识图谱把事实存成<strong>由关系连接的实体</strong>——用于当<strong>连接</strong>本身
-              就是问题时（表对此处理得很差）。
+              一个知识图谱把事实存成<strong>由关系连接的实体</strong>——用于当<strong>连接</strong>
+              本身 就是问题时（表对此处理得很差）。
             </li>
             <li>
-              原子是<strong>三元组</strong>：主语 → 谓语 → 宾语。把数十亿个堆成一张相互连接的网（Wikidata、
-              谷歌的知识图谱）。
+              原子是<strong>三元组</strong>：主语 → 谓语 →
+              宾语。把数十亿个堆成一张相互连接的网（Wikidata、 谷歌的知识图谱）。
             </li>
             <li>
-              一个<strong>本体</strong>（模式）定义实体/关系类型——<strong>数据 + 本体 = 知识图谱
-              </strong>；它也统一异构来源。
+              一个<strong>本体</strong>（模式）定义实体/关系类型——
+              <strong>数据 + 本体 = 知识图谱</strong>；它也统一异构来源。
             </li>
             <li>
-              构建它：<strong>实体/关系抽取</strong>（NLP/LLM）+ <strong>实体消解</strong>（关键所在——
-              「是不是同一样东西？」；错误会腐蚀一切）。
+              构建它：<strong>实体/关系抽取</strong>（NLP/LLM）+ <strong>实体消解</strong>
+              （关键所在—— 「是不是同一样东西？」；错误会腐蚀一切）。
             </li>
             <li>
               用 <strong>SPARQL/Cypher</strong> 查询表做不到的<strong>多跳</strong>问题。
               <strong>GraphRAG</strong> 把 LLM 锚定在带类型的、可追溯的事实上（减少幻觉）。
             </li>
             <li>
-              代价：<strong>构建/维护昂贵</strong>、实体消解错误、陈旧化、僵硬的模式。当关系是核心时才
-              用它——而非用于一切。
+              代价：<strong>构建/维护昂贵</strong>
+              、实体消解错误、陈旧化、僵硬的模式。当关系是核心时才 用它——而非用于一切。
             </li>
           </ul>
         </Callout>

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,8 @@
         "autoprefixer": "^10.4.16",
         "eslint": "^9.39.4",
         "eslint-config-next": "^16.2.7",
+        "husky": "^9.1.7",
+        "lint-staged": "^17.0.8",
         "postcss": "^8.4.32",
         "prettier": "^3.8.1",
         "tailwindcss": "^3.4.0"
@@ -2304,6 +2306,22 @@
         "url": "https://github.com/sponsors/epoberezkin"
       }
     },
+    "node_modules/ansi-escapes": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-7.3.0.tgz",
+      "integrity": "sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "environment": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
@@ -2919,6 +2937,85 @@
         "node": ">= 6"
       }
     },
+    "node_modules/cli-cursor": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-5.0.0.tgz",
+      "integrity": "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "restore-cursor": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-5.2.0.tgz",
+      "integrity": "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "slice-ansi": "^8.0.0",
+        "string-width": "^8.2.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/cli-truncate/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
     "node_modules/client-only": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
@@ -3267,6 +3364,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"
+      }
+    },
+    "node_modules/environment": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/environment/-/environment-1.1.0.tgz",
+      "integrity": "sha512-xUtoPkMggbz0MPyPiIWr1Kp4aeWJjDZ6SMvURhimjdZgsRuDplF5/s9hcgGhyXMhs+6vpnuoiZ2kFiu3FMnS8Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/es-abstract": {
@@ -3971,6 +4081,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/eventemitter3": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-5.0.4.tgz",
+      "integrity": "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/extend": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
@@ -4142,17 +4259,6 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
-    "node_modules/foreground-child/node_modules/signal-exit": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
-      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/isaacs"
-      }
-    },
     "node_modules/fraction.js": {
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-4.3.7.tgz",
@@ -4235,6 +4341,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-east-asian-width": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/get-east-asian-width/-/get-east-asian-width-1.6.0.tgz",
+      "integrity": "sha512-QRbvDIbx6YklUe6RxeTeleMR0yv3cYH6PsPZHcnVn7xv7zO1BHN8r0XETu8n6Ye3Q+ahtSarc3WgtNWmehIBfA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/get-intrinsic": {
@@ -4575,6 +4694,22 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/husky": {
+      "version": "9.1.7",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-9.1.7.tgz",
+      "integrity": "sha512-5gs5ytaNjBrh5Ow3zrvdUUY+0VxIuWVL4i9irt6friV+BqdCfmV11CQTWMiBYWHbXhco+J1kHfTOUkePhCDvMA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "husky": "bin.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/typicode"
       }
     },
     "node_modules/ignore": {
@@ -5319,6 +5454,125 @@
       "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
       "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="
     },
+    "node_modules/lint-staged": {
+      "version": "17.0.8",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-17.0.8.tgz",
+      "integrity": "sha512-B2P/d+jVW0UXOQ0MVMLrB/9ydA1P+zz6jYfdrbbEd9ur3S2rcbduFWKiUCC02Sm5hbC8nrm7y24WuYMG54HfxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "listr2": "^10.2.1",
+        "picomatch": "^4.0.4",
+        "string-argv": "^0.3.2",
+        "tinyexec": "^1.2.4"
+      },
+      "bin": {
+        "lint-staged": "bin/lint-staged.js"
+      },
+      "engines": {
+        "node": ">=22.22.1"
+      },
+      "funding": {
+        "url": "https://opencollective.com/lint-staged"
+      },
+      "optionalDependencies": {
+        "yaml": "^2.9.0"
+      }
+    },
+    "node_modules/lint-staged/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/listr2": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/listr2/-/listr2-10.2.2.tgz",
+      "integrity": "sha512-JtNtbZj8q5BnDMR7trpwvwk3RIrANtIVzEUm8w7amp6xelLgyuq+4WZoTH913XaQAoH/cNdYhaNzBPA2U3xbDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cli-truncate": "^5.2.0",
+        "eventemitter3": "^5.0.4",
+        "log-update": "^6.1.0",
+        "rfdc": "^1.4.1",
+        "wrap-ansi": "^10.0.0"
+      },
+      "engines": {
+        "node": ">=22.13.0"
+      }
+    },
+    "node_modules/listr2/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/string-width": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.1.tgz",
+      "integrity": "sha512-IIaP0g3iy9Cyy18w3M9YcaDudujEAVHKt3a3QJg1+sr/oX96TbaGUubG0hJyCjCBThFH+tFpcIyoUHUn1ogaLA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/listr2/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/listr2/node_modules/wrap-ansi": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-10.0.0.tgz",
+      "integrity": "sha512-SGcvg80f0wUy2/fXES19feHMz8E0JoXv2uNgHOu4Dgi2OrCy1lqwFYEJz1BLbDI0exjPMe/ZdzZ/YpGECBG/aQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "string-width": "^8.2.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -5340,6 +5594,131 @@
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/log-update": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-6.1.0.tgz",
+      "integrity": "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-escapes": "^7.0.0",
+        "cli-cursor": "^5.0.0",
+        "slice-ansi": "^7.1.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/log-update/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/slice-ansi": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-7.1.2.tgz",
+      "integrity": "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "is-fullwidth-code-point": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/log-update/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/log-update/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
     },
     "node_modules/longest-streak": {
       "version": "3.1.0",
@@ -6196,6 +6575,19 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mimic-function": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-function/-/mimic-function-5.0.1.tgz",
+      "integrity": "sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/minimatch": {
       "version": "9.0.9",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
@@ -6538,6 +6930,22 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/onetime": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-7.0.0.tgz",
+      "integrity": "sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mimic-function": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/optionator": {
@@ -7131,6 +7539,23 @@
         "url": "https://github.com/privatenumber/resolve-pkg-maps?sponsor=1"
       }
     },
+    "node_modules/restore-cursor": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-5.1.0.tgz",
+      "integrity": "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "onetime": "^7.0.0",
+        "signal-exit": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/reusify": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
@@ -7139,6 +7564,13 @@
         "iojs": ">=1.0.0",
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/rfdc": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/rfdc/-/rfdc-1.4.1.tgz",
+      "integrity": "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/run-parallel": {
       "version": "1.2.0",
@@ -7469,6 +7901,51 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/slice-ansi": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-8.0.0.tgz",
+      "integrity": "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^6.2.3",
+        "is-fullwidth-code-point": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/slice-ansi?sponsor=1"
+      }
+    },
+    "node_modules/slice-ansi/node_modules/is-fullwidth-code-point": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-5.1.0.tgz",
+      "integrity": "sha512-5XHYaSyiqADb4RnZ1Bdad6cPp8Toise4TzEjcOYDHZkTCbKgiUl7WTUCpNWHuxmDt91wnsZBc9xinNzopv3JMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "get-east-asian-width": "^1.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7513,6 +7990,16 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/string-argv": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/string-argv/-/string-argv-0.3.2.tgz",
+      "integrity": "sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.6.19"
       }
     },
     "node_modules/string-width": {
@@ -7998,6 +8485,16 @@
       "resolved": "https://registry.npmjs.org/tiny-inflate/-/tiny-inflate-1.0.3.tgz",
       "integrity": "sha512-pkY1fj1cKHb2seWDy0B16HeWyczlJA9/WW3u3c4z/NiWDsO3DOU5D7nhTLE9CF0yXv/QZFY7sEJmj24dK+Rrqw==",
       "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.2.4.tgz",
+      "integrity": "sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
       "version": "0.2.17",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
     "lint": "eslint .",
     "format": "prettier --write \"**/*.{js,jsx,json,css,md}\" --ignore-path .gitignore --ignore-path .prettierignore",
     "format:check": "prettier --check \"**/*.{js,jsx,json,css,md}\" --ignore-path .gitignore --ignore-path .prettierignore",
-    "deploy": "vercel --prod"
+    "deploy": "vercel --prod",
+    "prepare": "husky"
+  },
+  "lint-staged": {
+    "*.{js,jsx,json,css,md}": "prettier --write --ignore-path .gitignore --ignore-path .prettierignore"
   },
   "dependencies": {
     "@emailjs/browser": "^4.4.1",
@@ -51,6 +55,8 @@
     "autoprefixer": "^10.4.16",
     "eslint": "^9.39.4",
     "eslint-config-next": "^16.2.7",
+    "husky": "^9.1.7",
+    "lint-staged": "^17.0.8",
     "postcss": "^8.4.32",
     "prettier": "^3.8.1",
     "tailwindcss": "^3.4.0"


### PR DESCRIPTION
Follow-up to the now-blocking Prettier gate (#17). Two things:

1. **Fixes the red `v5` gate** — `components/knowledge/content/information-retrieval.jsx` had drifted and was failing the blocking format check. Now formatted.
2. **Adds a husky + lint-staged pre-commit hook** so the gate stays green: staged `*.{js,jsx,json,css,md}` files are auto-formatted on commit, so new work can't land unformatted.

## Details
- `husky` + `lint-staged` added as devDependencies; `prepare` script wires husky on install.
- `.husky/pre-commit` runs `npx lint-staged`; config runs `prettier --write` (honouring `.gitignore` + `.prettierignore`).
- Verified the hook fires: this PR's own commit was auto-processed by lint-staged.

## Verified locally
- `npm run lint` → 0 errors
- `npm run format:check` → clean on all tracked files

🤖 Generated with [Claude Code](https://claude.com/claude-code)