### PR TITLE
fix: og.jsx font-fetch reliability, middleware->proxy rename, changelog

### DIFF
--- a/locales/en-AU.json
+++ b/locales/en-AU.json
@@ -844,6 +844,7 @@
     "heading": "Changelog",
     "intro": "What changed. Version {version} and counting.",
     "entries": [
+      "Site-wide performance pass: KaTeX scoped to the /knowledge pages that use it, font preload trimmed, Edge Proxy skips static assets, homepage-only structured data no longer ships on every page. Also fixed stale image caching and a font-family CSS bug; blog builds ~3x faster.",
       "Blog: 6 posts with Mermaid diagrams, RSS feed at /blog/feed.xml, newsletter signup component. Service worker: self-destructing on activate for cache hygiene.",
       "Blog infrastructure: markdown pipeline (gray-matter + remark), PostCard, blog listing + individual post pages.",
       "Dark mode on 50+ pages (IntelligenceSection, DatasetCard, ContactSection, all section landing pages, strategic.jsx).",

--- a/locales/zh-Hans.json
+++ b/locales/zh-Hans.json
@@ -699,6 +699,7 @@
     "heading": "更新日志",
     "intro": "更新了什么。版本 {version}，仍在继续。",
     "entries": [
+      "全站性能优化：KaTeX 仅在实际使用的 /knowledge 页面加载，精简字体预加载，Edge Proxy 跳过静态资源请求，仅首页需要的结构化数据不再随每个页面加载。同时修复了图片缓存过期与字体字族 CSS 错配问题，博客构建速度提升约 3 倍。",
       "博客：6 篇文章，含 Mermaid 图表、位于 /blog/feed.xml 的 RSS 订阅、邮件订阅组件。Service worker：激活时自我销毁以保持缓存整洁。",
       "博客基础设施：markdown 管线（gray-matter + remark）、PostCard、博客列表与单篇文章页面。",
       "为 50+ 个页面添加深色模式（IntelligenceSection、DatasetCard、ContactSection、所有板块着陆页、strategic.jsx）。",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rin-contact",
-  "version": "5.22.1",
+  "version": "5.23.0",
   "private": true,
   "scripts": {
     "dev": "next dev --webpack",

--- a/pages/api/og.jsx
+++ b/pages/api/og.jsx
@@ -13,24 +13,33 @@ const SUB2 = "#AAAAAA";
 // Edge Functions may persist module state across invocations.
 let fontCache = null;
 
+// Returns [] on failure rather than throwing, so a cold-start network hiccup
+// against jsdelivr degrades to satori's built-in font instead of breaking
+// social-preview generation outright. fontCache stays null on failure so the
+// next invocation retries instead of caching a bad result.
 async function getFonts() {
   if (fontCache) return fontCache;
 
-  const [interRegular, interSemiBold] = await Promise.all([
-    fetch("https://cdn.jsdelivr.net/fontsource/fonts/inter@latest/latin-400-normal.ttf").then((r) =>
-      r.arrayBuffer()
-    ),
-    fetch("https://cdn.jsdelivr.net/fontsource/fonts/inter@latest/latin-600-normal.ttf").then((r) =>
-      r.arrayBuffer()
-    ),
-  ]);
+  try {
+    const [interRegular, interSemiBold] = await Promise.all([
+      fetch("https://cdn.jsdelivr.net/fontsource/fonts/inter@latest/latin-400-normal.ttf").then(
+        (r) => r.arrayBuffer()
+      ),
+      fetch("https://cdn.jsdelivr.net/fontsource/fonts/inter@latest/latin-600-normal.ttf").then(
+        (r) => r.arrayBuffer()
+      ),
+    ]);
 
-  fontCache = [
-    { name: "Inter", data: interRegular, weight: 400, style: "normal" },
-    { name: "Inter", data: interSemiBold, weight: 600, style: "normal" },
-  ];
+    fontCache = [
+      { name: "Inter", data: interRegular, weight: 400, style: "normal" },
+      { name: "Inter", data: interSemiBold, weight: 600, style: "normal" },
+    ];
 
-  return fontCache;
+    return fontCache;
+  } catch (err) {
+    console.error("og.jsx: failed to fetch Inter fonts, falling back to satori default", err);
+    return [];
+  }
 }
 
 // ── Handler ────────────────────────────────────────────────────────────────────

--- a/pages/info/changelog.jsx
+++ b/pages/info/changelog.jsx
@@ -6,6 +6,7 @@ import pkg from "../../package.json";
 // Version + date are stable identifiers; the change descriptions are localised
 // via infoChangelog.entries (index-aligned, newest first).
 const RELEASES = [
+  { version: "5.23.0", date: "2026-07" },
   { version: "5.22.1", date: "2026-06" },
   { version: "5.22.0", date: "2026-06" },
   { version: "5.21.0", date: "2026-05" },

--- a/proxy.js
+++ b/proxy.js
@@ -29,7 +29,7 @@ function isCliClient(userAgent = "") {
   return CLI.some((token) => userAgent.toLowerCase().includes(token));
 }
 
-export function middleware(request) {
+export function proxy(request) {
   const { pathname } = request.nextUrl;
   const ua = request.headers.get("user-agent") ?? "";
 
@@ -60,8 +60,8 @@ export const config = {
   // rewrite never ran for `curl rin.contact`. List "/" explicitly as well.
   // Also exclude static file extensions (fonts, images, css, etc. under
   // /public) — none of them need the CLI-detection or .well-known logic
-  // below, so skipping the middleware invocation for them removes an Edge
-  // Function hop from every font/image/stylesheet request on every page.
+  // below, so skipping the proxy invocation for them removes a request hop
+  // from every font/image/stylesheet request on every page.
   matcher: [
     "/",
     "/((?!api|_next/static|_next/image|.*\\.(?:css|html|ico|jpe?g|js|json|pdf|png|svg|txt|webmanifest|woff2?|xml)$).*)",


### PR DESCRIPTION
## Summary
- \`pages/api/og.jsx\`: wrap the cold-start Inter font fetch in try/catch — falls back to satori's default font instead of breaking OG image generation outright on a jsdelivr hiccup.
- Renamed \`middleware.js\` → \`proxy.js\` per Next.js 16's deprecation (nextjs.org/docs/messages/middleware-to-proxy). Same logic, function renamed \`middleware\` → \`proxy\` per the official migration guide.
- Added the site-wide performance pass as a v5.23.0 entry on \`/info/changelog\` (both locales), bumped \`package.json\`.

## Test plan
- [x] \`npm run build\` succeeds, middleware deprecation warning gone
- [x] \`npm run lint\` — 0 errors
- [x] Verified \`v5.23.0\` + new changelog text renders in both \`/info/changelog\` (en-AU) and \`/zh-Hans/info/changelog\` build output

🤖 Generated with [Claude Code](https://claude.com/claude-code)