### PR TITLE
chore: add Vercel Speed Insights, disable X-Powered-By header

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -3,6 +3,7 @@ const path = require("path");
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   trailingSlash: true,
+  poweredByHeader: false,
 
   i18n: {
     locales: ["en-AU", "zh-Hans"],

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "rin-contact",
-  "version": "5.22.1",
+  "version": "5.23.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rin-contact",
-      "version": "5.22.1",
+      "version": "5.23.0",
       "dependencies": {
         "@emailjs/browser": "^4.4.1",
         "@tailwindcss/typography": "^0.5.19",
         "@vercel/analytics": "^2.0.1",
         "@vercel/og": "^0.11.1",
+        "@vercel/speed-insights": "^2.0.0",
         "clsx": "^2.1.0",
         "gray-matter": "^4.0.3",
         "katex": "^0.17.0",
@@ -2264,6 +2265,44 @@
       },
       "optionalDependencies": {
         "sharp": "^0.34.5"
+      }
+    },
+    "node_modules/@vercel/speed-insights": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@vercel/speed-insights/-/speed-insights-2.0.0.tgz",
+      "integrity": "sha512-jwkNcrTeafWxjmWq4AHBaptSqZiJkYU5adLC9QBSqeim0GcqDMgN5Ievh8OG1rJ6W3A4l1oiP7qr9CWxGuzu3w==",
+      "license": "Apache-2.0",
+      "peerDependencies": {
+        "@sveltejs/kit": "^1 || ^2",
+        "next": ">= 13",
+        "nuxt": ">= 3",
+        "react": "^18 || ^19 || ^19.0.0-rc",
+        "svelte": ">= 4",
+        "vue": "^3",
+        "vue-router": "^4"
+      },
+      "peerDependenciesMeta": {
+        "@sveltejs/kit": {
+          "optional": true
+        },
+        "next": {
+          "optional": true
+        },
+        "nuxt": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "svelte": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        },
+        "vue-router": {
+          "optional": true
+        }
       }
     },
     "node_modules/acorn": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@tailwindcss/typography": "^0.5.19",
     "@vercel/analytics": "^2.0.1",
     "@vercel/og": "^0.11.1",
+    "@vercel/speed-insights": "^2.0.0",
     "clsx": "^2.1.0",
     "gray-matter": "^4.0.3",
     "katex": "^0.17.0",

--- a/pages/_app.jsx
+++ b/pages/_app.jsx
@@ -16,6 +16,10 @@ const Analytics = dynamic(
   () => import("@vercel/analytics/react").then((m) => ({ default: m.Analytics })),
   { ssr: false }
 );
+const SpeedInsights = dynamic(
+  () => import("@vercel/speed-insights/react").then((m) => ({ default: m.SpeedInsights })),
+  { ssr: false }
+);
 
 const CustomCursor = dynamic(() => import("@/components/ui/CustomCursor"), { ssr: false });
 const BootOverlay = dynamic(() => import("@/components/ui/BootOverlay"), { ssr: false });
@@ -349,6 +353,7 @@ function MyApp({ Component, pageProps }) {
           </main>
           <Footer />
           <Analytics debug={false} />
+          <SpeedInsights debug={false} />
         </div>
       </I18nProvider>
     </ThemeProvider>


### PR DESCRIPTION
## Summary
- Added \`@vercel/speed-insights\` for real-user Core Web Vitals monitoring (LCP, INP, CLS) — closes the loop on the recent performance work with real traffic data instead of synthetic checks only. Same lazy dynamic-import pattern as the existing Analytics component; its script origin (\`va.vercel-scripts.com\`) is already allowed by the CSP.
- \`next.config.js\`: \`poweredByHeader: false\` — stop sending \`X-Powered-By: Next.js\` on every response.

## Test plan
- [x] \`npm run build\` succeeds
- [x] \`npm run lint\` — 0 errors
- [ ] Confirm \`X-Powered-By\` header is absent on the deployed preview
- [ ] Confirm Speed Insights data starts appearing in the Vercel dashboard after merge (takes a little traffic to populate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)