### PR TITLE
fix: resolve Search Console Breadcrumbs itemListElement error

### DIFF
--- a/pages/_document.jsx
+++ b/pages/_document.jsx
@@ -177,38 +177,6 @@ const WEBSITE_SCHEMA = {
   },
 };
 
-const PROFILE_PAGE_SCHEMA = {
-  "@context": "https://schema.org",
-  "@type": "ProfilePage",
-  "@id": "https://rin.contact/#profilepage",
-  url: "https://rin.contact",
-  name: "Rin Huang (黄孙创宇) — Official Portfolio",
-  datePublished: "2024-01-01T00:00:00+10:30",
-  dateModified: "2026-03-10T00:00:00+10:30",
-  mainEntity: { "@id": "https://rin.contact/#person" },
-  about: { "@id": "https://rin.contact/#person" },
-  // isPartOf links this page into the WebSite entity — completing the entity graph
-  isPartOf: { "@id": "https://rin.contact/#website" },
-  // breadcrumb cross-reference tightens the structured data graph
-  breadcrumb: { "@id": "https://rin.contact/#breadcrumb" },
-  // primaryImageOfPage helps Google associate the OG image with this entity in image search
-  primaryImageOfPage: {
-    "@type": "ImageObject",
-    "@id": "https://rin.contact/#og-image",
-    url: "https://rin.contact/api/og/?title=Rin%20Huang&subtitle=Senior%20Data%20Analyst%20%40%20SAPOL&section=home",
-    width: 1200,
-    height: 630,
-    caption:
-      "Rin Huang (黄孙创宇, Sunchuangyu Huang) — Senior Data Analyst & Research Software Engineer",
-  },
-  // significantLinks tells Google that LinkedIn/GitHub are related pages, not competitors
-  significantLinks: ["https://linkedin.com/in/sunchuangyuhuang", "https://github.com/rNLKJA"],
-  speakable: {
-    "@type": "SpeakableSpecification",
-    cssSelector: ["h1", "#hero-bio", ".hero-role", "h2"],
-  },
-};
-
 class MyDocument extends Document {
   static async getInitialProps(ctx) {
     const initialProps = await Document.getInitialProps(ctx);
@@ -346,13 +314,16 @@ class MyDocument extends Document {
             type="application/ld+json"
             dangerouslySetInnerHTML={{ __html: JSON.stringify(WEBSITE_SCHEMA) }}
           />
-          <script
-            type="application/ld+json"
-            dangerouslySetInnerHTML={{ __html: JSON.stringify(PROFILE_PAGE_SCHEMA) }}
-          />
-          {/* BREADCRUMB_SCHEMA / PROJECTS_SCHEMA / CREDENTIALS_SCHEMA moved to
-              pages/index.jsx — they describe homepage-only content and were
-              previously shipped in every page's <head>. */}
+          {/* PROFILE_PAGE_SCHEMA / BREADCRUMB_SCHEMA / PROJECTS_SCHEMA /
+              CREDENTIALS_SCHEMA moved to pages/index.jsx — they describe
+              homepage-only content (ProfilePage's url is literally
+              "https://rin.contact") and were previously shipped in every
+              page's <head>. Keeping ProfilePage global left a dangling
+              breadcrumb: {"@id": "#breadcrumb"} reference on every other
+              page once BREADCRUMB_SCHEMA moved — Search Console flagged
+              that as a Breadcrumbs rich-result error (missing
+              itemListElement) since it evaluates structured data per page,
+              not across pages. */}
         </Head>
 
         {/*

--- a/pages/index.jsx
+++ b/pages/index.jsx
@@ -7,6 +7,38 @@ import SeoHead from "@/components/seo/SeoHead";
 // Moved from pages/_document.jsx — these describe homepage-only content
 // (career timeline anchors, project list, credentials) and were previously
 // shipped in every page's <head> even though only the homepage uses them.
+const PROFILE_PAGE_SCHEMA = {
+  "@context": "https://schema.org",
+  "@type": "ProfilePage",
+  "@id": "https://rin.contact/#profilepage",
+  url: "https://rin.contact",
+  name: "Rin Huang (黄孙创宇) — Official Portfolio",
+  datePublished: "2024-01-01T00:00:00+10:30",
+  dateModified: "2026-03-10T00:00:00+10:30",
+  mainEntity: { "@id": "https://rin.contact/#person" },
+  about: { "@id": "https://rin.contact/#person" },
+  // isPartOf links this page into the WebSite entity — completing the entity graph
+  isPartOf: { "@id": "https://rin.contact/#website" },
+  // breadcrumb cross-reference tightens the structured data graph
+  breadcrumb: { "@id": "https://rin.contact/#breadcrumb" },
+  // primaryImageOfPage helps Google associate the OG image with this entity in image search
+  primaryImageOfPage: {
+    "@type": "ImageObject",
+    "@id": "https://rin.contact/#og-image",
+    url: "https://rin.contact/api/og/?title=Rin%20Huang&subtitle=Senior%20Data%20Analyst%20%40%20SAPOL&section=home",
+    width: 1200,
+    height: 630,
+    caption:
+      "Rin Huang (黄孙创宇, Sunchuangyu Huang) — Senior Data Analyst & Research Software Engineer",
+  },
+  // significantLinks tells Google that LinkedIn/GitHub are related pages, not competitors
+  significantLinks: ["https://linkedin.com/in/sunchuangyuhuang", "https://github.com/rNLKJA"],
+  speakable: {
+    "@type": "SpeakableSpecification",
+    cssSelector: ["h1", "#hero-bio", ".hero-role", "h2"],
+  },
+};
+
 const BREADCRUMB_SCHEMA = {
   "@context": "https://schema.org",
   "@type": "BreadcrumbList",
@@ -687,7 +719,11 @@ export default function Home() {
           }}
         />
 
-        {/* ── Breadcrumb / projects / credentials structured data — homepage-only ── */}
+        {/* ── Profile page / breadcrumb / projects / credentials — homepage-only ── */}
+        <script
+          type="application/ld+json"
+          dangerouslySetInnerHTML={{ __html: JSON.stringify(PROFILE_PAGE_SCHEMA) }}
+        />
         <script
           type="application/ld+json"
           dangerouslySetInnerHTML={{ __html: JSON.stringify(BREADCRUMB_SCHEMA) }}


### PR DESCRIPTION
## Summary
Google Search Console flagged a critical Breadcrumbs structured data issue: "Missing field 'itemListElement'". Root cause: my earlier performance PR (#21) moved `BREADCRUMB_SCHEMA` to homepage-only, but left `PROFILE_PAGE_SCHEMA` (which references it via `breadcrumb: {"@id": "#breadcrumb"}`) rendering globally in `_document.jsx`. Every non-homepage page ended up with a dangling breadcrumb reference pointing at nothing, since Google validates structured data per page, not across pages.

## Fix
Move `PROFILE_PAGE_SCHEMA` to `pages/index.jsx`, alongside the other homepage-only schemas. It was already homepage-specific (`url: "https://rin.contact"`), so this also fixes a pre-existing semantic mismatch (it was describing the homepage but rendering everywhere), not just the dangling reference.

## Test plan
- [x] Build + lint clean
- [x] Verified `about.html` (representative non-homepage page): only `Person` + `WebSite` schemas, no `ProfilePage`/breadcrumb reference
- [x] Verified homepage: `BreadcrumbList` still has all 5 `itemListElement` entries intact
- [ ] Re-request validation in Search Console after this deploys (Google needs to re-crawl before the issue clears from the report)

🤖 Generated with [Claude Code](https://claude.com/claude-code)